### PR TITLE
Move security headers to separate file

### DIFF
--- a/ansible/files/etc/nginx/sites-available/default
+++ b/ansible/files/etc/nginx/sites-available/default
@@ -20,6 +20,10 @@ server {
         root /var/www/acme-challenges;
     }
 
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Content-Type-Options "nosniff";
+
     location / {
         return 301 https://$host$request_uri;
     }

--- a/ansible/tasks/database.yml
+++ b/ansible/tasks/database.yml
@@ -1,7 +1,7 @@
 ---
 # Contains application-agnostic database tasks
 - block:
-  - name: "ensure mariadb is installed and managable"
+  - name: "ensure mariadb is installed and manageable"
     apt:
         name: "{{item}}"
         state: present

--- a/ansible/tasks/nginx.yml
+++ b/ansible/tasks/nginx.yml
@@ -83,7 +83,6 @@
     enabled: yes
     state: started
 
-
 - name: "request certificates"
   command: >
     certbot certonly \
@@ -101,7 +100,6 @@
       {% endfor %}
   with_items: "{{ websites }}"
 
-
 # TODO add renewals
 
 - name: "create website directories"
@@ -113,6 +111,16 @@
     state: directory
   with_items: "{{ websites }}"
   when: item.custom_config is undefined
+
+- name: "create nginx includes directory"
+  file:
+    dest: "/etc/nginx/includes"
+    state: directory
+
+- name: "copy security http headers"
+  template:
+    src: "etc/nginx/includes/security-headers.conf.j2"
+    dest: "/etc/nginx/includes/security-headers.conf"
 
 - name: "copy website nginx configuration"
   template:
@@ -131,7 +139,7 @@
 
 - name: "create htpasswd.d directory for basic auth files"
   file:
-    dest: /etc/nginx/htpasswd.d
+    dest: "/etc/nginx/htpasswd.d"
     owner: root
     group: root
     state: directory

--- a/ansible/templates/etc/nginx/includes/security-headers.conf.j2
+++ b/ansible/templates/etc/nginx/includes/security-headers.conf.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+add_header X-Frame-Options "SAMEORIGIN";
+add_header X-XSS-Protection "1; mode=block";
+add_header X-Content-Type-Options "nosniff";
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";

--- a/ansible/templates/etc/nginx/nginx.conf.j2
+++ b/ansible/templates/etc/nginx/nginx.conf.j2
@@ -55,15 +55,10 @@ http {
   ssl_stapling on;
   ssl_stapling_verify on;
 
-
   ##
   # Other security settings
   ##
   server_tokens off;
-
-  add_header X-Frame-Options "SAMEORIGIN";
-  add_header X-XSS-Protection "1; mode=block";
-  add_header X-Content-Type-Options "nosniff";
 
   ##
   # Logging Settings

--- a/ansible/templates/etc/nginx/sites-available/koala.j2
+++ b/ansible/templates/etc/nginx/sites-available/koala.j2
@@ -11,8 +11,7 @@ server {
 	ssl_certificate {{ ssl_certificate }};
 	ssl_certificate_key {{ ssl_certificate_key }};
 
-	# HSTS
-	add_header Strict-Transport-Security 'max-age=31536000';
+	include includes/security-headers.conf;
 
 	return 301 https://$subdomain.{{ canonical_hostname }}$request_uri;
 }
@@ -25,7 +24,7 @@ server {
 	ssl_certificate {{ ssl_certificate }};
 	ssl_certificate_key {{ ssl_certificate_key }};
 
-	# HSTS is already enforced in rails
+	# Security headers already enforced in Rails
 
 	root /var/www/koala.{{ canonical_hostname }}/public;
 

--- a/ansible/templates/etc/nginx/sites-available/metrics.j2
+++ b/ansible/templates/etc/nginx/sites-available/metrics.j2
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 upstream netdata {
   server 127.0.0.1:19999;
 }
@@ -10,6 +11,8 @@ server {
 
   ssl_certificate      /etc/letsencrypt/live/metrics.{{ canonical_hostname }}/fullchain.pem;
   ssl_certificate_key  /etc/letsencrypt/live/metrics.{{ canonical_hostname }}/privkey.pem;
+
+  include includes/security-headers.conf;
 
   location / {
     auth_basic "Grafieken en meer";

--- a/ansible/templates/etc/nginx/sites-available/website.conf.j2
+++ b/ansible/templates/etc/nginx/sites-available/website.conf.j2
@@ -14,7 +14,7 @@ server {
   root /var/www/{{ item.user }}/{{ item.main_hostname }};
   index index.html index.htm index.php;
 
-  add_header Strict-Transport-Security "max-age=31536000";
+  include includes/security-headers.conf;
 
   location ~ \.php$ {
     try_files %uri =404;


### PR DESCRIPTION
I have moved the security HTTP headers to a separate file, to avoid duplication and make it easier to let Rails deal with this itself for Koala. 

The default configuration is an exception, since in an HTTP-only config HSTS should not be added.

Also fixed a few spelling/style errors in the process.