### PR TITLE
Set locale variables (Fixes #52)

### DIFF
--- a/ansible/files/etc/default/locale
+++ b/ansible/files/etc/default/locale
@@ -1,0 +1,3 @@
+LANG="en_US.UTF-8"
+LANGUAGE="en_US.UTF-8"
+LC_ALL="en_US.UTF-8"

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -33,14 +33,14 @@
       become: yes
 
   tasks:
-    - include: tasks/auth.yml
     - include: tasks/users.yml
+    - include: tasks/auth.yml
+    - include: tasks/locale.yml
     - include: tasks/packages.yml
     - include: tasks/fail2ban.yml
     - include: tasks/nginx.yml
     - include: tasks/firewall.yml
+    - include: tasks/monitoring.yml
     - include: tasks/database.yml
     - include: tasks/koala.yml
     - include: tasks/studystatus.yml
-    - include: tasks/monitoring.yml
-...

--- a/ansible/tasks/locale.yml
+++ b/ansible/tasks/locale.yml
@@ -1,0 +1,5 @@
+---
+- name: "copy locale variables"
+  copy:
+    src: etc/default/locale
+    dest: /etc/default/locale


### PR DESCRIPTION
This sets the `LANGUAGE` AND `LC_ALL` variables in `/etc/default/locale` in order to prevent bugs/errors later on.

While including the new yml-file in `main.yml`, I also changed the order of the included files a bit, to make more sense. For instance it's safer to first create the admin users, before removing its keys from the root account.