### PR TITLE
Add reboot handler

### DIFF
--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -30,7 +30,23 @@
 
     - name: "systemctl daemon-reload"
       command: systemctl daemon-reload
-      become: yes
+
+    - name: "issue reboot command"
+      shell: sleep 2 && /sbin/reboot
+      async: 60
+      poll: 0
+      ignore_errors: true
+      listen: "reboot server"
+
+    - name: "wait for server to finish rebooting"
+      wait_for:
+        host: "{{ inventory_hostname }}"
+        search_regex: "OpenSSH"
+        port: "22"
+        delay: "20"
+      connection: local
+      become: false
+      listen: "reboot server"
 
   tasks:
     - include: tasks/auth.yml

--- a/ansible/tasks/auth.yml
+++ b/ansible/tasks/auth.yml
@@ -24,7 +24,7 @@
     regexp: "^PermitRootLogin "
     line: "PermitRootLogin no"
     state: present
-  notify: restart ssh
+  notify: "reboot server"
 
 - name: "disable password authentication over ssh"
   lineinfile:
@@ -32,7 +32,7 @@
     regexp: "^PasswordAuthentication "
     line: "PasswordAuthentication no"
     state: present
-  notify: restart ssh
+  notify: "reboot server"
 
 - name: "remove public keys for root account"
   file:


### PR DESCRIPTION
I added a reboot handler, because this seems to be necessary to apply the changes made to the sshd config (#51).

Even when there's some other way to apply the sshd changes, I'd still recommend to keep the handler listed (but unused), because it took quite some trial & error to get the parameters right.

It might prove to be useful for other things, like applying kernel upgrades.