### PR TITLE
Fix bug in MariaDB root account

### DIFF
--- a/ansible/tasks/database.yml
+++ b/ansible/tasks/database.yml
@@ -9,7 +9,6 @@
         - mariadb-server
         - python-mysqldb
     tags:
-        - database
         - packages
 
   - name: "ensure database is enabled and running"
@@ -19,7 +18,6 @@
         state: started
     tags:
         - service
-        - database
 
   - name: "generate and set database root password if not set"
     mysql_user:


### PR DESCRIPTION
[Earlier](https://github.com/svsticky/skyblue/issues/25#issuecomment-273117623) I noticed that the password for the root account of MariaDB did not work.

Apparently there is an existing authentication plugin set for the `root` user, that supersedes the
root password that we set. This ensures that any authentication plugin is removed.