### PR TITLE
Fix PHP

### DIFF
--- a/ansible/tasks/nginx.yml
+++ b/ansible/tasks/nginx.yml
@@ -132,10 +132,13 @@
     dest: "/etc/nginx/includes"
     state: directory
 
-- name: "copy security http headers"
+- name: "copy nginx include files"
   template:
-    src: "etc/nginx/includes/security-headers.conf.j2"
-    dest: "/etc/nginx/includes/security-headers.conf"
+    src: "etc/nginx/includes/{{ item }}.j2"
+    dest: "/etc/nginx/includes/{{ item }}"
+  with_items:
+    - security-headers.conf
+    - php-parameters.conf
 
 - name: "copy nginx configurations for each website"
   template:

--- a/ansible/templates/etc/nginx/includes/php-parameters.conf.j2
+++ b/ansible/templates/etc/nginx/includes/php-parameters.conf.j2
@@ -1,0 +1,35 @@
+# {{ ansible_managed }}
+
+location ~ \.php$ {
+  try_files $uri =404;
+  fastcgi_split_path_info ^(.+\.php)(/+)$;
+  fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+  fastcgi_index index.php;
+
+  fastcgi_param   QUERY_STRING            $query_string;
+  fastcgi_param   REQUEST_METHOD          $request_method;
+  fastcgi_param   CONTENT_TYPE            $content_type;
+  fastcgi_param   CONTENT_LENGTH          $content_length;
+
+  fastcgi_param   SCRIPT_FILENAME         $request_filename;
+  fastcgi_param   SCRIPT_NAME             $fastcgi_script_name;
+  fastcgi_param   REQUEST_URI             $request_uri;
+  fastcgi_param   DOCUMENT_URI            $document_uri;
+  fastcgi_param   DOCUMENT_ROOT           $document_root;
+  fastcgi_param   SERVER_PROTOCOL         $server_protocol;
+
+  fastcgi_param   GATEWAY_INTERFACE       CGI/1.1;
+  fastcgi_param   SERVER_SOFTWARE         nginx/$nginx_version;
+
+  fastcgi_param   REMOTE_ADDR             $remote_addr;
+  fastcgi_param   REMOTE_PORT             $remote_port;
+  fastcgi_param   SERVER_ADDR             $server_addr;
+  fastcgi_param   SERVER_PORT             $server_port;
+  fastcgi_param   SERVER_NAME             $server_name;
+
+  fastcgi_param   HTTPS                   $https if_not_empty;
+  fastcgi_param   HTTP_PROXY              "";
+
+  # PHP only, required if PHP was built with --enable-force-cgi-redirect
+  fastcgi_param   REDIRECT_STATUS         200;
+}

--- a/ansible/templates/etc/nginx/sites-available/website.conf.j2
+++ b/ansible/templates/etc/nginx/sites-available/website.conf.j2
@@ -16,38 +16,5 @@ server {
   index index.html index.htm index.php;
 
   include includes/security-headers.conf;
-
-  location ~ \.php$ {
-    try_files %uri =404;
-    fastcgi_split_path_info ^(.+\.php)(/+)$;
-    fastcgi_pass unix:/tmp/php5-fpm.sock;
-    fastcgi_index index.php;
-
-    fastcgi_param   QUERY_STRING            $query_string;
-    fastcgi_param   REQUEST_METHOD          $request_method;
-    fastcgi_param   CONTENT_TYPE            $content_type;
-    fastcgi_param   CONTENT_LENGTH          $content_length;
-
-    fastcgi_param   SCRIPT_FILENAME         $request_filename;
-    fastcgi_param   SCRIPT_NAME             $fastcgi_script_name;
-    fastcgi_param   REQUEST_URI             $request_uri;
-    fastcgi_param   DOCUMENT_URI            $document_uri;
-    fastcgi_param   DOCUMENT_ROOT           $document_root;
-    fastcgi_param   SERVER_PROTOCOL         $server_protocol;
-
-    fastcgi_param   GATEWAY_INTERFACE       CGI/1.1;
-    fastcgi_param   SERVER_SOFTWARE         nginx/$nginx_version;
-
-    fastcgi_param   REMOTE_ADDR             $remote_addr;
-    fastcgi_param   REMOTE_PORT             $remote_port;
-    fastcgi_param   SERVER_ADDR             $server_addr;
-    fastcgi_param   SERVER_PORT             $server_port;
-    fastcgi_param   SERVER_NAME             $server_name;
-
-    fastcgi_param   HTTPS                   $https if_not_empty;
-    fastcgi_param   HTTP_PROXY              "";
-
-    # PHP only, required if PHP was built with --enable-force-cgi-redirect
-    fastcgi_param   REDIRECT_STATUS         200;
-  }
+  include includes/php-parameters.conf;
 }


### PR DESCRIPTION
PHP wasn't working. Not sure how we didn't notice this before, but there was a typo in `try_files` (`%uri` instead of `$uri`), and the socket path referenced in nginx wasn't the same as in PHP's configuration itself.

Also, I moved the parameters used by nginx to a separate file that's included in the regular website configuration. Avoids some duplication.