### PR TITLE
Enhance unattended-upgrades config

### DIFF
--- a/ansible/templates/etc/apt/apt.conf.d/50unattended-upgrades.j2
+++ b/ansible/templates/etc/apt/apt.conf.d/50unattended-upgrades.j2
@@ -13,6 +13,15 @@ Unattended-Upgrade::Allowed-Origins {
 
 Unattended-Upgrade::Package-Blacklist { };
 
-// TODO enable upgrade email notifcations. First need to
-// have email working.
-// Unattended-Upgrade::Mail "root@localhost";
+// Do automatic removal of new unused dependencies after the upgrade
+// (equivalent to apt-get autoremove)
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+
+// Automatically reboot *WITHOUT CONFIRMATION*
+//  if the file /var/run/reboot-required is found after the upgrade
+Unattended-Upgrade::Automatic-Reboot "true";
+
+// If automatic reboot is enabled and needed, reboot at the specific
+// time instead of immediately
+//  Default: "now"
+Unattended-Upgrade::Automatic-Reboot-Time "04:30";


### PR DESCRIPTION
- Added flag that removes new unused dependencies after an upgrade (`apt-get autoremove` behavior)
- Enabled scheduled reboot (at 04:30), if an upgrade is installed that requires a reboot to be applied (most likely kernel upgrades).
- Removed old comment about email, which is superseded by #90.