### PR TITLE
Add notifications for runs and extra info in MOTD

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Godspeed!
 
 The code/scripts in this repository depends on the following software:
 
- - Ansible ~> 2.1
+ - Ansible ~> 2.2
+ - [slacktee](https://github.com/course-hero/slacktee) (no config necessary)
  - Any POSIX compatible shell
 
 ## Ansible playbook

--- a/ansible/scripts/run-playbook.sh
+++ b/ansible/scripts/run-playbook.sh
@@ -1,3 +1,16 @@
 #!/bin/sh
-set -e
-ANSIBLE_SSH_PIPELINING=true ansible-playbook -i hosts --ask-become-pass $@
+
+GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+GIT_REVISION="$(git rev-parse HEAD)"
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+alias slacktee="slacktee.sh --config '${GIT_ROOT}/ansible/templates/etc/slacktee.conf' --plain-text --username 'Ansible'"
+
+echo "*Deployment of playbook \"_$1_\" started by ${USER}*\n_(branch: ${GIT_BRANCH} - revision \"${GIT_REVISION}\")_" | slacktee --icon ':construction:' --attachment '#46c4ff' > /dev/null
+
+ANSIBLE_SSH_PIPELINING=true ansible-playbook -i "${GIT_ROOT}/ansible/hosts" --ask-become-pass --extra-vars "playbook_revision=${GIT_REVISION}" "$@"
+
+if [ "$?" = "0" ]; then
+  echo "*Deployment of playbook \"_$1_\" successfully completed*\n_(branch: ${GIT_BRANCH} - revision \"${GIT_REVISION}\")_" | slacktee --icon ':ok_hand:' --attachment 'good' > /dev/null
+else
+  echo "*Deployment of playbook \"_$1_\" FAILED!*\n_(branch: ${GIT_BRANCH} - revision \"${GIT_REVISION}\")_" | slacktee --icon ':exclamation:' --attachment 'danger' > /dev/null
+fi

--- a/ansible/tasks/motd.yml
+++ b/ansible/tasks/motd.yml
@@ -1,13 +1,22 @@
 ---
-- name: install plumbing
+- name: "remove help text from motd"
+  file:
+    path: "/etc/update-motd.d/{{ item }}"
+    state: absent
+  with_items:
+    - "10-help-text"
+    - "51-cloudguest"
+
+- name: "install toilet"
   apt:
     pkg: toilet
     state: present
 
-- name: hook up plumbing
+- name: "copy motd templates"
   template:
-    src: "templates/etc/update-motd.d/01-skyblue-header.j2"
-    dest: "/etc/update-motd.d/01-skyblue-header"
-    owner: root
-    group: root
+    src: "templates/etc/update-motd.d/{{ item }}.j2"
+    dest: "/etc/update-motd.d/{{ item }}"
     mode: 0755
+  with_items:
+    - "01-skyblue-header"
+    - "02-playbook-revision"

--- a/ansible/tasks/packages.yml
+++ b/ansible/tasks/packages.yml
@@ -23,8 +23,8 @@
 
 - name: "configure unattended-upgrades and slacktee"
   template:
-    src: "{{ item }}.j2"
+    src: "{{ item }}"
     dest: "/{{ item }}"
   with_items:
-    - etc/apt/apt.conf.d/50unattended-upgrades
+    - etc/apt/apt.conf.d/50unattended-upgrades.j2
     - etc/slacktee.conf

--- a/ansible/templates/etc/slacktee.conf
+++ b/ansible/templates/etc/slacktee.conf
@@ -1,0 +1,9 @@
+# Ansible managed
+
+webhook_url="https://hooks.slack.com/services/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"
+upload_token=""
+channel="alerts"
+tmp_dir="/tmp"
+username="DEFAULT"
+icon="poop"
+attachment="danger"

--- a/ansible/templates/etc/slacktee.conf.j2
+++ b/ansible/templates/etc/slacktee.conf.j2
@@ -1,7 +1,0 @@
-webhook_url="{{ slacktee.webhook_url }}"
-upload_token=""
-channel="alerts"
-tmp_dir="/tmp"
-username="DEFAULT"
-icon="poop"
-attachment="danger"

--- a/ansible/templates/etc/update-motd.d/01-skyblue-header.j2
+++ b/ansible/templates/etc/update-motd.d/01-skyblue-header.j2
@@ -1,3 +1,6 @@
 #!/bin/sh
+# {{ ansible_managed }}
 
+echo ""
 toilet -F gay -f future Skyblue
+echo ""

--- a/ansible/templates/etc/update-motd.d/02-playbook-revision.j2
+++ b/ansible/templates/etc/update-motd.d/02-playbook-revision.j2
@@ -1,0 +1,5 @@
+#!/bin/sh
+# {{ ansible_managed }}
+
+echo "The most recently deployed playbook revision"
+echo "is \"{{ playbook_revision | default('unknown') }}\"."

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -191,4 +191,3 @@ koala:
 slacktee:
   revision: 2dd488b93fa13d305d27c1c820641e600845710e
   checksum: sha256:b59522b40de167e5c88ddf09f5d02560759902fc503e0bd3cea5c1fa45b780df
-  webhook_url: https://hooks.slack.com/services/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


### PR DESCRIPTION
When running in production, it's handy to know what revision of the playbook is currently deployed. E.g. when we aren't sure if someone else already deployed the latest changes. For this I implemented two measures.

The first one adds the commit hash of the local playbook to the server's MOTD during deployment. This can be used as a version number if we aren't sure what changes have been deployed. I also removed some unnecessary information from the stock MOTD.

The second feature adds some notifications to Slack. I modified `scripts/run-playbook.sh` to push a message to Slack just before a run of a playbook, and another one when the run is over. It looks at the [exit code of ansible-playbook](https://manpages.debian.org/testing/ansible/ansible-playbook.1.en.html#EXIT_STATUS) to adapt the second message to show whether the run ended successful or not.

To send messages to Slack, slacktee, which we already used on the server, becomes a (local) dependency. Also reflected that in the README. I configured it to use the same slacktee config that was already present in the repository for remote use, so locally no configuration is necessary.

Fixes #81.

![slack](https://cloud.githubusercontent.com/assets/6782150/24267496/c27c0f4a-100a-11e7-92ff-024697b17ed2.png)