### PR TITLE
Create handler that restarts Koala on changes

### DIFF
--- a/ansible/handlers.yml
+++ b/ansible/handlers.yml
@@ -1,13 +1,25 @@
 ---
-- name: "reload nginx"
+- name: "check if koala is running"
+  command: "systemctl is-active koala"
+  register: "koala_running"
+  listen: "restart koala"
+
+- name: "restart koala service"
   service:
-    name: "nginx"
-    state: "reloaded"
+    name: "koala"
+    state: "restarted"
+  when: koala_running.rc == 0
+  listen: "restart koala"
 
 - name: "restart fail2ban"
   service:
     name: "fail2ban"
     state: "restarted"
+
+- name: "reload nginx"
+  service:
+    name: "nginx"
+    state: "reloaded"
 
 - name: "systemctl daemon-reload"
   command: "systemctl daemon-reload"

--- a/ansible/tasks/koala.yml
+++ b/ansible/tasks/koala.yml
@@ -7,6 +7,7 @@
       state: "present"
       system: true
       shell: "/bin/bash"
+    notify: "restart koala"
     tags:
       - "ruby"
       - "koala"
@@ -72,6 +73,7 @@
      name: "yarn"
      state: "present"
      update_cache: true
+    notify: "restart koala"
 
   - name: "ensure koala service file is present"
     template:
@@ -81,6 +83,7 @@
       path: "etc/systemd/system/koala.service"
     notify:
       - "systemctl daemon-reload"
+      - "restart koala"
 
   become: true
 
@@ -134,6 +137,7 @@
         - "{{ rbenv_versions.results }}"
       loop_control:
         label: "{{ item.0.repo }}"
+      notify: "restart koala"
 
   - name: "ensure environment variables are set in .bashrc"
     blockinfile:
@@ -143,6 +147,7 @@
       block: |
         export PATH="$HOME/.rbenv/bin:$PATH"
         eval "$(rbenv init -)"
+    notify: "restart koala"
     tags:
       - "koala"
       - "ruby"
@@ -154,6 +159,7 @@
     args:
       executable: "/bin/bash"
       creates: "/home/koala/.rbenv/versions/{{ koala.ruby_version }}"
+    notify: "restart koala"
     tags:
       - "ruby"
       - "koala"
@@ -234,6 +240,7 @@
       src: "templates/var/www/koala/.rbenv-vars.j2"
       dest: "/var/www/koala.{{ canonical_hostname }}/.rbenv-vars"
       mode: "0700"
+    notify: "restart koala"
     tags:
       - "koala"
 
@@ -245,6 +252,7 @@
       chdir: "/var/www/koala.{{ canonical_hostname }}"
     register: "koala_gem_result"
     changed_when: "'Installing' in koala_gem_result.stdout"
+    notify: "restart koala"
     tags:
       - "koala"
 
@@ -255,6 +263,7 @@
     args:
       chdir: "/var/www/koala.{{ canonical_hostname }}"
       creates: "/var/www/koala.{{ canonical_hostname }}/tmp"
+    notify: "restart koala"
     tags:
       - "koala"
 
@@ -263,6 +272,7 @@
       path: "/var/www/koala.{{ canonical_hostname }}/log"
       state: "directory"
       mode: "0775"
+    notify: "restart koala"
     tags:
       - "koala"
 
@@ -274,6 +284,7 @@
       chdir: "/var/www/koala.{{ canonical_hostname }}"
     register: "koala_assets_result"
     changed_when: koala_assets_result.stdout.find("Already up-to-date.") == -1
+    notify: "restart koala"
 
     # This block only runs when Koala was already present, and needs to be
     # updated. Makes a backup of Koala's db before performing any operations on
@@ -377,6 +388,7 @@
       group: "koala"
     vars:
       path: "home/koala/unicorn.sh"
+    notify: "restart koala"
 
   - name: "place koala's nginx configuration"
     template:


### PR DESCRIPTION
This adds a handler that checks if Koala is running, and restarts it if so. 

This is called on most Koala-related tasks (except the few that **always** return a "changed" result), so that if there any changes resulting from those tasks, they get applied to the Koala instance that might be running at that moment.

Fixes #120.