### PR TITLE
Make it possible to delete a website

### DIFF
--- a/ansible/playbooks/oneoff-purge-old-websites.yml
+++ b/ansible/playbooks/oneoff-purge-old-websites.yml
@@ -1,0 +1,89 @@
+---
+- hosts: all
+  user: "ansible"
+  become: true
+  become_user: "root"
+  become_method: "sudo"
+  force_handlers: true
+
+  vars_files:
+      - "../vars.yml"
+  vars_prompt:
+      - name: "confirm"
+        default: 'ABORT'
+        prompt:
+          "The playbook you are about to execute will DELETE ALL DATA OF
+          ALL WEBSITES WHOSE \"STATE\" IS SET TO ABSENT. Are you CERTAIN that
+          you wish to continue? If so, enter `obliteration`. Any other value
+          will abort."
+
+  tasks:
+      - assert:
+          that:
+            - "confirm == 'obliteration'"
+
+      # Revoke website certificate, to avoid renewal notifications from the CA
+      - name: "revoke certificate(s)"
+        # --non-interactive makes sure command never waits for user input
+        command:
+          "certbot revoke
+          --non-interactive
+          {% if staging_certificates and (item.real_certificate is not defined
+          or item.real_certificate == false) %}
+          --staging
+          {% endif %}
+          --cert-path /etc/letsencrypt/live/{{ item.name }}/cert.pem
+          --reason cessationofoperation"
+        with_items: "{{ websites }}"
+        # Added because Certbot will error if cert is already deleted
+        failed_when: false
+        when: item.state == "absent"
+
+      - name: "delete certificate(s)"
+        command:
+          "certbot delete
+          --non-interactive
+          --cert-name {{ item.name }}"
+        with_items: "{{ websites }}"
+        # Added because Certbot will error if cert is already deleted
+        failed_when: false
+        when: item.state == "absent"
+
+      - name: "delete webroot(s)"
+        file:
+          path:
+            "/var/www/{% if item.user is defined %}{{ item.user }}/{% endif
+            %}{{ item.name }}"
+          state: "absent"
+        with_items: "{{ websites }}"
+        when:
+          # List is evaluated as logical AND
+          - item.state == "absent"
+          - item.custom_config is undefined
+
+      - name: "delete database(s)"
+        command: "mysql -NBe 'DROP DATABASE IF EXISTS {{ item.database }};'"
+        with_items: "{{ websites }}"
+        when:
+          # List is evaluated as logical AND
+          - item.state == "absent"
+          - item.database is defined
+
+      - name: "delete database user(s)"
+        command: "mysql -NBe 'DROP USER {{ item.database }}@localhost;'"
+        with_items: "{{ websites }}"
+        # Added because MySQL will error if user is already deleted. "DROP USER
+        # IF EXISTS" is added in MariaDB 10.1.3, but we're not on that version
+        # yet.
+        failed_when: false
+        when:
+          # List is evaluated as logical AND
+          - item.state == "absent"
+          - item.database is defined
+
+      - debug:
+          msg:
+            "The certificates of all absent websites are revoked and deleted.
+            Also, its webroot, database and db user (if existing) are deleted.
+            Remember to delete any specific templates/tasks from this repository
+            yourself."

--- a/ansible/tasks/database.yml
+++ b/ansible/tasks/database.yml
@@ -43,7 +43,10 @@
   - name: "create website databases"
     command: "mysql -NBe 'create database if not exists {{ item.database }};'"
     with_items: "{{ websites }}"
-    when: item.database is defined
+    when:
+      # List is evaluated as logical AND
+      - item.state == "present"
+      - item.database is defined
     loop_control:
       label: "{{ item.name }}"
 
@@ -58,7 +61,10 @@
       `{{ item.database }}`@`localhost` identified via mysql_native_password
       using "{{ secret_mysql[item.database]['hash'] }}";'
     with_items: "{{ websites }}"
-    when: item.database is defined
+    when:
+      # List is evaluated as logical AND
+      - item.state == "present"
+      - item.database is defined
     loop_control:
       label: "{{ item.name }}"
 

--- a/ansible/tasks/nginx.yml
+++ b/ansible/tasks/nginx.yml
@@ -129,6 +129,7 @@
   with_items: "{{ websites }}"
   register: "certbot_output"
   changed_when: "'no action taken' not in certbot_output.stdout"
+  when: item.state == "present"
   loop_control:
     label: "{{ item.name }}"
 
@@ -150,7 +151,10 @@
     mode: "2775"
     state: "directory"
   with_items: "{{ websites }}"
-  when: item.custom_config is undefined
+  when:
+    # List is evaluated as logical AND
+    - item.state == "present"
+    - item.custom_config is undefined
   loop_control:
     label: "{{ item.name }}"
 
@@ -191,7 +195,10 @@
     src: "templates/etc/nginx/sites-available/website.conf.j2"
     dest: "/etc/nginx/sites-available/{{ item.name }}.conf"
   with_items: "{{ websites }}"
-  when: item.custom_config is undefined
+  when:
+    # List is evaluated as logical AND
+    - item.state == "present"
+    - item.custom_config is undefined
   notify: "reload nginx"
   loop_control:
     label: "{{ item.name }}"
@@ -215,7 +222,10 @@
     path: "/etc/nginx/sites-enabled/{{ item.name }}.conf"
     state: "link"
   with_items: "{{ websites }}"
-  when: item.custom_config is undefined
+  when:
+    # List is evaluated as logical AND
+    - item.state == "present"
+    - item.custom_config is undefined
   notify: "reload nginx"
   loop_control:
     label: "{{ item.name }}"
@@ -234,3 +244,16 @@
   file:
     path: "/etc/nginx/htpasswd.d"
     state: "directory"
+
+- name: "delete nginx configurations of absent websites"
+  file:
+    path: "/etc/nginx/{{ item[0] }}/{{ item[1].name }}.conf"
+  with_nested:
+    -
+      - "sites-available"
+      - "sites-enabled"
+    - "{{ websites }}"
+  when: item[1].state == "absent"
+  notify: "reload nginx"
+  loop_control:
+    label: "{{ item[0] }}/{{ item[1].name }}.conf"

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -200,12 +200,16 @@ websites:
       - "www.dgdarc.nl"
       - "dgdarc.com"
       - "www.dgdarc.com"
+    state: "present"
 
   - name: "digidecs.{{ canonical_hostname }}"
     user: "commit"
     alternative_names:
       - "declaraties.{{ canonical_hostname }}"
       - "declareren.{{ canonical_hostname }}"
+    # You have to remove the task include of digidecs.yml to remove this
+    # completely
+    state: "present"
 
   - name: "indievelopment.{{ canonical_hostname }}"
     user: "indievelopment"
@@ -215,6 +219,7 @@ websites:
       - "www.indievelopment.nl"
       - "indiedevelopment.nl"
       - "www.indiedevelopment.nl"
+    state: "present"
 
   - name: "koala.{{ canonical_hostname }}"
     custom_config: true
@@ -223,12 +228,17 @@ websites:
       - "intro.{{ canonical_hostname }}"
       - "leden.{{ canonical_hostname }}"
       - "members.{{ canonical_hostname }}"
+    # You have to remove the task include of koala.yml to remove this completely
+    state: "present"
 
   - name: "metrics.{{ canonical_hostname }}"
     custom_config: true
     # Hostnames have to be set in custom nginx config as well!
     alternative_names:
       - "status.{{ canonical_hostname }}"
+    # You have to remove the task include of monitoring.yml to remove this
+    # completely
+    state: "present"
 
   - name: "phpmyadmin.{{ canonical_hostname }}"
     custom_config: true
@@ -236,10 +246,14 @@ websites:
     # Hostnames have to be set in custom nginx config as well!
     alternative_names:
       - "pma.{{ canonical_hostname }}"
+    # You have to remove the task include of phpmyadmin.yml to remove this
+    # completely
+    state: "present"
 
   - name: "radio.{{ canonical_hostname }}"
     user: "commit"
     alternative_names: []
+    state: "present"
 
   - name: "savadaba.{{ canonical_hostname }}"
     custom_config: true
@@ -247,23 +261,28 @@ websites:
     alternative_names:
       - "savadaba.nl"
       - "www.savadaba.nl"
+    state: "present"
 
   - name: "sodi.{{ canonical_hostname }}"
     alternative_names:
       - "sodi.nl"
       - "www.sodi.nl"
+    # You have to remove the task include of sodi.yml to remove this completely
+    state: "present"
 
   - name: "stichting.{{ canonical_hostname }}"
     user: "stichting"
     alternative_names:
       - "stichtingsticky.nl"
       - "www.stichtingsticky.nl"
+    state: "present"
 
   - name: "studytrip.{{ canonical_hostname }}"
     user: "studytrip"
     database: "studytrip"
     alternative_names:
       - "studiereis.{{ canonical_hostname }}"
+    state: "present"
 
   - name: "{{ canonical_hostname }}"
     user: "commit"
@@ -276,21 +295,25 @@ websites:
       - "www.stickyutrecht.nl"
       - "studieverenigingsticky.nl"
       - "www.studieverenigingsticky.nl"
+    state: "present"
 
   - name: "symposium.{{ canonical_hostname }}"
     user: "symposium"
     alternative_names:
       - "idata.{{ canonical_hostname }}"
+    state: "present"
 
   - name: "wintersport.{{ canonical_hostname }}"
     user: "wintersport"
     alternative_names: []
+    state: "present"
 
   - name: "execut.{{ canonical_hostname }}"
     user: "symposium"
     alternative_names:
       - "execut.nl"
       - "www.execut.nl"
+    state: "present"
 
 slacktee:
   repo: "https://github.com/course-hero/slacktee.git"


### PR DESCRIPTION
Like we already had for users, I added a "state" to the websites. This makes it possible to set it to "absent" for websites we want to disable/delete.

Just setting it to "absent" and running the main playbook, only deletes the nginx config. To make it explicit when data is removed, I moved that part to a separate play.

That playbook revokes the certificate, deletes all traces of the cert, purges the webroot (for non-custom sites), deletes the database, and its database user.

Fixes #80.