### PR TITLE
Verify integrity of backups

### DIFF
--- a/ansible/playbooks/restore-backup.yml
+++ b/ansible/playbooks/restore-backup.yml
@@ -1,8 +1,13 @@
 ---
-# This playbook can be run on staging to test the integrity of the backup, and
+# Prerequisites to run this playbook: A staging or production server which is
+# set up using the main playbook.
+#
+# This playbook can be run on staging to test the integrity of the backup, or
 # in production to set up a new production environment. Because it always needs
-# access to the production AWS bucket, when running on staging you need to add
-# "--vault-id production@prompt" to the run-playbook.sh call!
+# access to the production AWS bucket, run-playbook.sh will always prompt for
+# the production Vault passphrase when running this playbook, also when it's
+# done on staging.
+
 - hosts: "all"
   user: "ansible"
   become: true
@@ -39,12 +44,15 @@
 
     - name: "create temporary directory to store backup archives"
       tempfile:
-          prefix: "backup-restore-test."
+          prefix: "prod-backup-restore."
           state: "directory"
       register: "backup_restore_tmp_dir"
 
     - name: "find latest backups"
       shell:
+        # This parses the output of awscli to get the filenames of the backups
+        # that are present, sorts them alphabetically (which means by date
+        # because of our naming system), and takes the top one (so most recent)
         "aws s3 ls s3://sticky-automatic-backups/{{ item }}/
         | awk -F' ' '{print $NF}'
         | sort -r
@@ -56,7 +64,7 @@
         - "websites/databases"
 
     - name: "download latest backups"
-      shell:
+      command:
         "aws s3 cp s3://sticky-automatic-backups/\
         {{ item.item }}/{{ item.stdout }}
         {{ backup_restore_tmp_dir.path }}/{{ item.stdout }}"
@@ -78,11 +86,11 @@
       loop_control:
         label: "{{ item.stdout }}"
 
-    - name: "remove all existing databases"
+    - name: "remove all existing databases on target server"
       shell:
-        "mysql -e "show databases"
+        "mysql -e \"show databases\"
         | grep -v -e Database -e mysql -e information_schema
-        | gawk '{print "drop database " $1 ";select sleep(0.1);"}'
+        | awk '{print \"drop database \" $1 \";select sleep(0.1);\"}'
         | mysql"
 
     - name: "restore production databases"
@@ -97,7 +105,8 @@
         path: "{{ backup_restore_tmp_dir.path }}"
         state: "absent"
 
-    - debug:
+    - name: "print success message"
+      debug:
         msg:
           "The backup has been restored. Check the target folders, the
           databases and the operation of the server to determine its

--- a/ansible/playbooks/restore-backup.yml
+++ b/ansible/playbooks/restore-backup.yml
@@ -1,0 +1,106 @@
+---
+# This playbook can be run on staging to test the integrity of the backup, and
+# in production to set up a new production environment. Because it always needs
+# access to the production AWS bucket, when running on staging you need to add
+# "--vault-id production@prompt" to the run-playbook.sh call!
+- hosts: "all"
+  user: "ansible"
+  become: true
+  become_user: "root"
+  become_method: "sudo"
+  force_handlers: true
+
+  vars_prompt:
+    - name: "confirm"
+      default: 'ABORT'
+      private: false
+      prompt: |-
+        This playbook will restore a backup of the production server. This will
+        replace the data in many directories. There should be twice the size of
+        this backup available as free disk space, since the archives have to be
+        extracted.
+        Assume you will lose *any existing data* on this server. Are you
+        CERTAIN that you wish to continue? If so, enter "obliteration". Any
+        other value will abort
+
+  tasks:
+    - name: "check that confirmation is given"
+      assert:
+        that:
+          - "confirm == 'obliteration'"
+
+    # We only need this when running on staging, to access
+    # the AWS bucket later that has the production backups
+    - name: "load secrets from production"
+      include_vars:
+        name: "production"
+        file: "../group_vars/production/vault.yml"
+      when: "'production' not in group_names"
+
+    - name: "create temporary directory to store backup archives"
+      tempfile:
+          prefix: "backup-restore-test."
+          state: "directory"
+      register: "backup_restore_tmp_dir"
+
+    - name: "find latest backups"
+      shell:
+        "aws s3 ls s3://sticky-automatic-backups/{{ item }}/
+        | awk -F' ' '{print $NF}'
+        | sort -r
+        | head -n1"
+      register: "backup_filenames"
+      with_items:
+        - "admins"
+        - "websites"
+        - "websites/databases"
+
+    - name: "download latest backups"
+      shell:
+        "aws s3 cp s3://sticky-automatic-backups/\
+        {{ item.item }}/{{ item.stdout }}
+        {{ backup_restore_tmp_dir.path }}/{{ item.stdout }}"
+      register: "downloaded_items"
+      with_items: "{{ backup_filenames.results }}"
+      loop_control:
+        label: "/{{ item.item }}/{{ item.stdout }}"
+
+    - name: "unpack admins and website backups"
+      unarchive:
+        src: "{{ backup_restore_tmp_dir.path }}/{{ item.stdout }}"
+        # The paths in the backup archives are relative to /, so this extracts
+        # them to the right location.
+        dest: "/"
+        remote_src: true
+      with_items: "{{ backup_filenames.results }}"
+      # Skip db backup here, because that's not an archive
+      when: "'websites/databases' != item.item"
+      loop_control:
+        label: "{{ item.stdout }}"
+
+    - name: "remove all existing databases"
+      shell:
+        "mysql -e "show databases"
+        | grep -v -e Database -e mysql -e information_schema
+        | gawk '{print "drop database " $1 ";select sleep(0.1);"}'
+        | mysql"
+
+    - name: "restore production databases"
+      shell: "zcat {{ backup_restore_tmp_dir.path }}/{{ item.stdout }} | mysql"
+      with_items: "{{ backup_filenames.results }}"
+      when: "item.item == 'websites/databases'"
+      loop_control:
+        label: "{{ item.stdout }}"
+
+    - name: "delete backup archives"
+      file:
+        path: "{{ backup_restore_tmp_dir.path }}"
+        state: "absent"
+
+    - debug:
+        msg:
+          "The backup has been restored. Check the target folders, the
+          databases and the operation of the server to determine its
+          integrity. Be aware that paths and configuration files will still
+          refer to the canonical hostname used in production, and might need to
+          be changed manually to make services work."

--- a/ansible/scripts/run-playbook.sh
+++ b/ansible/scripts/run-playbook.sh
@@ -66,6 +66,13 @@ case ${ENVIRONMENT} in
     fi
     ;;
   staging)
+    # Special scenario: When restore-backup.yml is run on staging, it needs to
+    # access the production Vault secrets, so this adds the prompt for that to
+    # the CLI arguments passed to ansible-playbook
+    if [[ ${ARGS[0]} == "playbooks/restore-backup.yml" ]]; then
+      ARGS[${#ARGS[@]}]="--vault-id"
+      ARGS[${#ARGS[@]}]="production@prompt"
+    fi
     ;;
   *)
     echo "$USAGE"

--- a/ansible/templates/home/ansible/.aws/config.j2
+++ b/ansible/templates/home/ansible/.aws/config.j2
@@ -6,3 +6,4 @@ aws_secret_access_key = {{ secret_backup_aws.secret_key }}
 
 output = text
 region = {{ aws_region }}
+payload_signing_enabled = true

--- a/ansible/templates/usr/local/bin/backup-to-s3.sh.j2
+++ b/ansible/templates/usr/local/bin/backup-to-s3.sh.j2
@@ -50,6 +50,9 @@ cleanup() {
 
 trap cleanup EXIT
 
+# Save time of backup in local timezone, for use in notification
+BACKUP_DATE=$(TZ='Europe/Amsterdam' date +'%F %R %:z')
+
 case "${SOURCE}" in
         admins)
           S3PATH="${SOURCE}"
@@ -89,8 +92,12 @@ case "${SOURCE}" in
           exit 1
 esac
 
-SUCCESS_MESSAGE="*{% if 'staging' in group_names %}_FROM STAGING:_ {% endif
-%}Backup of ${SOURCE} completed* _($(date +'%F %T %:z'))_"
+BACKUP_SIZE=$(stat --printf="%s" "{{ tmp_dir }}/${FILE}.${FILE_EXT}" | \
+numfmt --to=iec --suffix=B --format="%.2f")
+
+SUCCESS_MESSAGE="*{% if 'staging' in group_names %}__FROM STAGING:_ {% endif
+%}Backup of ${SOURCE} completed* _(${BACKUP_DATE})_\n_(Backup size: \
+${BACKUP_SIZE})_"
 
 ${HASH}sum "{{ tmp_dir }}/${FILE}.${FILE_EXT}" > \
 "{{ tmp_dir }}/${FILE}.${FILE_EXT}.${HASH}"
@@ -108,8 +115,8 @@ ${HASH}sum "{{ tmp_dir }}/${FILE}.${FILE_EXT}" > \
 
   ${HASH}sum --check "{{ tmp_dir }}/${FILE}.${FILE_EXT}.${HASH}"
 
-  echo "${SUCCESS_MESSAGE}" | /usr/local/bin/slacktee --plain-text --username \
-  'Backup service' --icon ':floppy_disk:' --attachment 'good'
+  echo -e "${SUCCESS_MESSAGE}" | /usr/local/bin/slacktee --plain-text\
+  --username 'Backup service' --icon ':floppy_disk:' --attachment 'good'
 } 1> /dev/null
 
 echo "Backup of ${SOURCE} successful!"

--- a/ansible/templates/usr/local/bin/backup-to-s3.sh.j2
+++ b/ansible/templates/usr/local/bin/backup-to-s3.sh.j2
@@ -29,8 +29,8 @@ if [[ -z ${1:-} ]]; then
 fi
 
 SOURCE="${1}"
-FILE="${SOURCE}-$(date +'%Y%m%d-%H%M%S')"
 HASH="sha256" # Choose from md5/sha1/sha224/sha256/sha384/sha512
+FILE_TITLE="${SOURCE}-$(date +'%Y%m%d-%H%M%S')"
 
 S3BUCKET="{% if 'staging' in group_names %}staging-{% endif
 %}sticky-automatic-backups"
@@ -38,12 +38,12 @@ S3BUCKET="{% if 'staging' in group_names %}staging-{% endif
 cleanup() {
   # Ensure files are deleted, in case script crashes
 
-  # Check because file extension is only set when a valid backup source is
+  # Check because complete file name is only set when a valid backup source is
   # passed
-  if [[ -n ${FILE_EXT:-} ]]; then
+  if [[ -n ${FILE_NAME:-} ]]; then
     {
-      rm -rf "{{ tmp_dir }}/${FILE}.${FILE_EXT}"
-      rm -rf "{{ tmp_dir }}/${FILE}.${FILE_EXT}.${HASH}"
+      rm -rf "{{ tmp_dir }}/${FILE_NAME}"
+      rm -rf "{{ tmp_dir }}/${FILE_NAME}.${HASH}"
     } 1> /dev/null
   fi
 }
@@ -56,17 +56,17 @@ BACKUP_DATE=$(TZ='Europe/Amsterdam' date +'%F %R %:z')
 case "${SOURCE}" in
         admins)
           S3PATH="${SOURCE}"
-          FILE_EXT="tar.gz"
+          FILE_NAME="${FILE_TITLE}.tar.gz"
 
           # Some directories excluded to save space, since they only contain
           # binaries/cache anyway.
           tar --exclude='home/koala/.rbenv' --exclude='home/koala/.bundle' \
-          --exclude='home/koala/.cache' -c -f - -C / home | gzip -9 > \
-          "{{ tmp_dir }}/${FILE}.${FILE_EXT}"
+          --exclude='home/koala/.cache' -c -f - -C / home | \
+          gzip -9 > "{{ tmp_dir }}/${FILE_NAME}"
           ;;
         websites)
           S3PATH="${SOURCE}"
-          FILE_EXT="tar.gz"
+          FILE_NAME="${FILE_TITLE}.tar.gz"
 
           # phpMyAdmin and SODI directories excluded because no other
           # committee can write to these folders and they are deployed from \
@@ -76,44 +76,40 @@ case "${SOURCE}" in
 	    --exclude='var/www/phpmyadmin.{{ canonical_hostname }}' \
             --exclude='var/www/sodi.{{ canonical_hostname }}' \
 	    --exclude='var/www/pretix/venv' \
-	    -c -f - -C / \
-          var/www | gzip -9 > "{{ tmp_dir }}/${FILE}.${FILE_EXT}"
+	    -c -f - -C / var/www | gzip -9 > "{{ tmp_dir }}/${FILE_NAME}"
           ;;
         databases)
           S3PATH="websites/${SOURCE}"
-          FILE_EXT="sql.gz"
+          FILE_NAME="${FILE_TITLE}.sql.gz"
 
           # Uses root's unix socket for authentication
-          mysqldump --all-databases | gzip -9 > \
-          "{{ tmp_dir }}/${FILE}.${FILE_EXT}"
+          mysqldump --all-databases | gzip -9 > "{{ tmp_dir }}/${FILE_NAME}"
           ;;
         *)
           print_to_stderr "${USAGE}"
           exit 1
 esac
 
-BACKUP_SIZE=$(stat --printf="%s" "{{ tmp_dir }}/${FILE}.${FILE_EXT}" | \
+BACKUP_SIZE=$(stat --printf="%s" "{{ tmp_dir }}/${FILE_NAME}" | \
 numfmt --to=iec --suffix=B --format="%.2f")
 
 SUCCESS_MESSAGE="*{% if 'staging' in group_names %}__FROM STAGING:_ {% endif
 %}Backup of ${SOURCE} completed* _(${BACKUP_DATE})_\n_(Backup size: \
 ${BACKUP_SIZE})_"
 
-${HASH}sum "{{ tmp_dir }}/${FILE}.${FILE_EXT}" > \
-"{{ tmp_dir }}/${FILE}.${FILE_EXT}.${HASH}"
+${HASH}sum "{{ tmp_dir }}/${FILE_NAME}" > "{{ tmp_dir }}/${FILE_NAME}.${HASH}"
 
 {
-  aws s3 cp "{{ tmp_dir }}/${FILE}.${FILE_EXT}" "s3://${S3BUCKET}/${S3PATH}/"
+  aws s3 cp "{{ tmp_dir }}/${FILE_NAME}" "s3://${S3BUCKET}/${S3PATH}/"
 
-  aws s3 cp "{{ tmp_dir }}/${FILE}.${FILE_EXT}.${HASH}" \
-  "s3://${S3BUCKET}/${S3PATH}/"
+  aws s3 cp "{{ tmp_dir }}/${FILE_NAME}.${HASH}" "s3://${S3BUCKET}/${S3PATH}/"
 
-  rm "{{ tmp_dir }}/${FILE}.${FILE_EXT}"
+  rm "{{ tmp_dir }}/${FILE_NAME}"
 
-  aws s3 cp "s3://${S3BUCKET}/${S3PATH}/${FILE}.${FILE_EXT}" \
-  "{{ tmp_dir }}/${FILE}.${FILE_EXT}"
+  aws s3 cp "s3://${S3BUCKET}/${S3PATH}/${FILE_NAME}" \
+  "{{ tmp_dir }}/${FILE_NAME}"
 
-  ${HASH}sum --check "{{ tmp_dir }}/${FILE}.${FILE_EXT}.${HASH}"
+  ${HASH}sum --check "{{ tmp_dir }}/${FILE_NAME}.${HASH}"
 
   echo -e "${SUCCESS_MESSAGE}" | /usr/local/bin/slacktee --plain-text\
   --username 'Backup service' --icon ':floppy_disk:' --attachment 'good'

--- a/ansible/templates/usr/local/bin/backup-to-s3.sh.j2
+++ b/ansible/templates/usr/local/bin/backup-to-s3.sh.j2
@@ -29,6 +29,8 @@ if [[ -z ${1:-} ]]; then
 fi
 
 SOURCE="${1}"
+# $FILE_TITLE, plus the extension that is added depending on the backup source,
+# will be the filename of the backup
 FILE_TITLE="${SOURCE}-$(date +'%Y%m%d-%H%M%S')"
 
 S3BUCKET="{% if 'staging' in group_names %}staging-{% endif
@@ -67,12 +69,12 @@ case "${SOURCE}" in
           # phpMyAdmin and SODI directories excluded because no other
           # committee can write to these folders and they are deployed from \
           # git anyway.
-	  # Pretix's virtualenv is excluded as it only contains binaries.
+          # Pretix's virtualenv is excluded as it only contains binaries.
           tar \
-	    --exclude='var/www/phpmyadmin.{{ canonical_hostname }}' \
+            --exclude='var/www/phpmyadmin.{{ canonical_hostname }}' \
             --exclude='var/www/sodi.{{ canonical_hostname }}' \
-	    --exclude='var/www/pretix/venv' \
-	    -c -f - -C / var/www | gzip -9 > "{{ tmp_dir }}/${FILE_NAME}"
+            --exclude='var/www/pretix/venv' \
+            -c -f - -C / var/www | gzip -9 > "{{ tmp_dir }}/${FILE_NAME}"
           ;;
         databases)
           S3PATH="websites/${SOURCE}"
@@ -89,7 +91,7 @@ esac
 BACKUP_SIZE=$(stat --printf="%s" "{{ tmp_dir }}/${FILE_NAME}" | \
 numfmt --to=iec --suffix=B --format="%.2f")
 
-SUCCESS_MESSAGE="*{% if 'staging' in group_names %}__FROM STAGING:_ {% endif
+SUCCESS_MESSAGE="*{% if 'staging' in group_names %}_FROM STAGING:_ {% endif
 %}Backup of ${SOURCE} completed* _(${BACKUP_DATE})_\n_(Backup size: \
 ${BACKUP_SIZE})_"
 
@@ -98,7 +100,7 @@ ${BACKUP_SIZE})_"
 
   rm "{{ tmp_dir }}/${FILE_NAME}"
 
-  echo -e "${SUCCESS_MESSAGE}" | /usr/local/bin/slacktee --plain-text\
+  echo -e "${SUCCESS_MESSAGE}" | /usr/local/bin/slacktee --plain-text \
   --username 'Backup service' --icon ':floppy_disk:' --attachment 'good'
 } 1> /dev/null
 

--- a/ansible/templates/usr/local/bin/backup-to-s3.sh.j2
+++ b/ansible/templates/usr/local/bin/backup-to-s3.sh.j2
@@ -29,7 +29,6 @@ if [[ -z ${1:-} ]]; then
 fi
 
 SOURCE="${1}"
-HASH="sha256" # Choose from md5/sha1/sha224/sha256/sha384/sha512
 FILE_TITLE="${SOURCE}-$(date +'%Y%m%d-%H%M%S')"
 
 S3BUCKET="{% if 'staging' in group_names %}staging-{% endif
@@ -41,10 +40,7 @@ cleanup() {
   # Check because complete file name is only set when a valid backup source is
   # passed
   if [[ -n ${FILE_NAME:-} ]]; then
-    {
-      rm -rf "{{ tmp_dir }}/${FILE_NAME}"
-      rm -rf "{{ tmp_dir }}/${FILE_NAME}.${HASH}"
-    } 1> /dev/null
+    rm -rf "{{ tmp_dir }}/${FILE_NAME}" 1> /dev/null
   fi
 }
 
@@ -97,19 +93,10 @@ SUCCESS_MESSAGE="*{% if 'staging' in group_names %}__FROM STAGING:_ {% endif
 %}Backup of ${SOURCE} completed* _(${BACKUP_DATE})_\n_(Backup size: \
 ${BACKUP_SIZE})_"
 
-${HASH}sum "{{ tmp_dir }}/${FILE_NAME}" > "{{ tmp_dir }}/${FILE_NAME}.${HASH}"
-
 {
   aws s3 cp "{{ tmp_dir }}/${FILE_NAME}" "s3://${S3BUCKET}/${S3PATH}/"
 
-  aws s3 cp "{{ tmp_dir }}/${FILE_NAME}.${HASH}" "s3://${S3BUCKET}/${S3PATH}/"
-
   rm "{{ tmp_dir }}/${FILE_NAME}"
-
-  aws s3 cp "s3://${S3BUCKET}/${S3PATH}/${FILE_NAME}" \
-  "{{ tmp_dir }}/${FILE_NAME}"
-
-  ${HASH}sum --check "{{ tmp_dir }}/${FILE_NAME}.${HASH}"
 
   echo -e "${SUCCESS_MESSAGE}" | /usr/local/bin/slacktee --plain-text\
   --username 'Backup service' --icon ':floppy_disk:' --attachment 'good'


### PR DESCRIPTION
This does two things.

- The backup size is added to backup notifications in Slack. This makes it possible to glance at that channel to see if a backup hasn't become ~0MB all of a sudden. It also changes the backup time in the notification to be in our local timezone.

- A separate playbook is added. It takes the backups made in production, and tries to restore them. We can use this periodically on a staging server to see if the backups still actually work, or use it to migrate the production environment. It checks the hashes, unpacks it to the paths as specified in the backups itself, and imports the databases. The only thing you have to do yourself, when deploying on staging, is change the restored paths of webroots to match the hostnames used in staging (*.**dev**.svsticky.nl).

Fixes #75, in my opinion.