### PR TITLE
Loosen dependency of Koala service on MariaDB

### DIFF
--- a/ansible/tasks/database.yml
+++ b/ansible/tasks/database.yml
@@ -11,6 +11,20 @@
     tags:
         - "packages"
 
+  - name: "create folder for mariadb override"
+    file:
+      path: "/etc/systemd/system/mysql.service.d"
+      state: "directory"
+    notify: "systemctl daemon-reload"
+
+  - name: "override parameters of mariadb service"
+    template:
+      src: "templates/{{ item }}.j2"
+      dest: "/{{ item }}"
+    with_items:
+      - "etc/systemd/system/mysql.service.d/override.conf"
+    notify: "systemctl daemon-reload"
+
   - name: "ensure database is enabled and running"
     service:
         name: "mysql"

--- a/ansible/templates/etc/systemd/system/koala.service.j2
+++ b/ansible/templates/etc/systemd/system/koala.service.j2
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=Run koala {{ koala.environment }} service
-Requires=mysql.service
+Wants=mysql.service
 After=network.target
 
 [Service]
@@ -17,6 +17,7 @@ ExecStart=/home/koala/webrick.sh
 User=koala
 Group=koala
 WorkingDirectory=/var/www/koala.{{ canonical_hostname }}
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/templates/etc/systemd/system/mysql.service.d/override.conf.j2
+++ b/ansible/templates/etc/systemd/system/mysql.service.d/override.conf.j2
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+
+[Service]
+Restart=always


### PR DESCRIPTION
Fixes #129.

Its main change is in Koala's service: It changes `Requires=mysql.service` to `Wants=mysql.service`. This will prevent Koala from stopping if MariaDB is stopped. 

Koala won't function without a DB, but without a DB connection Koala will present a 500, the same as nginx would do if Koala's wasn't running at all. So when the DB is down, nothing changes from the user's perspective. The upside is that if MySQL is started again, Koala is automatically in a functional state again. That will prevent the scenario from #129.

I've tested the following scenario's. Current situation:

- MariaDB is stopped -> Koala is stopped.
- MariaDB is started -> Koala unaffected.
- MariaDB is restarted -> Koala is restarted.
- Koala is started -> MariaDB is started.

New situation:

- MariaDB is stopped -> Koala unaffected (but not usable).
- MariaDB is started -> Koala unaffected (but if already active, usable again).
- MariaDB is restarted -> Koala unaffected.

Besides this, I've added `Restart=always` to both units for good measure.