### PR TITLE
Bind db backup service to MariaDB service

### DIFF
--- a/ansible/templates/etc/systemd/system/backup-databases.service.j2
+++ b/ansible/templates/etc/systemd/system/backup-databases.service.j2
@@ -2,6 +2,8 @@
 
 [Unit]
 Description=Backup of all MariaDB databases to AWS S3
+BindsTo=mysql.service
+After=mysql.service
 OnFailure=backup-fail@all\x20MariaDB\x20databases.service
 
 [Service]


### PR DESCRIPTION
Fixes #131.

This should make sure that the backup-databases service can never be active without the MariaDB service being already active. This is needed because the `mysqldump` command that backs up the databases needs to connect to MariaDB.

Seems to be the preferred way to accomplish this: https://www.freedesktop.org/software/systemd/man/systemd.unit.html#BindsTo=