### PR TITLE
Add the execut website to vars.yml

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -284,9 +284,11 @@ websites:
     user: "wintersport"
     alternative_names: []
 
-  - name: "execut.nl"
-    user: "execut"
-    alternative_names: []
+  - name: "execut.{{ canonical_hostname }}"
+    user: "symposium"
+    alternative_names:
+      - "execut.nl"
+      - "www.execut.nl"
 
 slacktee:
   repo: "https://github.com/course-hero/slacktee.git"


### PR DESCRIPTION
For the conference this year, we have our own domain: `execut.nl`. This should just work, right?