### PR TITLE
Add Rob's SSH key to the symposium user

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -159,6 +159,8 @@ users:
         state: "present"
       - id: "duijf.github.pub"
         state: "present"
+      - id: "RCdeWit.github.pub"
+        state: "present"
 
   - name: "wintersport"
     admin: false


### PR DESCRIPTION
Title says it. His key is already in `credentials/ssh`