### PR TITLE
Only reload nginx when actually needed

### DIFF
--- a/ansible/tasks/auth.yml
+++ b/ansible/tasks/auth.yml
@@ -146,3 +146,8 @@
   vars:
     path: "etc/ssh/sshd_config"
   notify: "reboot server"
+
+# Make sure the "reboot server" handler is run now (when notified), and not just
+# before Certbot's task, when the handlers are also flushed. Because otherwise
+# Certbot would fail, because the kernel's RNG wouldn't be seeded yet.
+- meta: "flush_handlers"

--- a/ansible/tasks/nginx.yml
+++ b/ansible/tasks/nginx.yml
@@ -43,13 +43,13 @@
     state: "link"
   notify: "reload nginx"
 
-# This enables the nginx service, and reloads or starts it if necessary. Let's
-# Encrypt depends on this.
-- name: "enable and start/reload nginx"
+# This enables the nginx service, and starts it if necessary. Certbot depends on
+# this.
+- name: "enable and start nginx"
   service:
     name: "nginx"
     enabled: true
-    state: "reloaded"
+    state: "started"
 
 - name: "Delete default html directory"
   file:
@@ -95,6 +95,9 @@
     - "etc/systemd/system/certbot.timer.d/override.conf"
     - "etc/systemd/system/certbot-fail.service"
   notify: "systemctl daemon-reload"
+
+# To make sure nginx is reloaded if needed
+- meta: "flush_handlers"
 
 - name: "request certificates"
   # --non-interactive makes sure command never waits for user input


### PR DESCRIPTION
_Small bugfix, made a PR because I found an interesting problem and maybe there's a neater solution, even though it's fairly trivial._

nginx was reloaded every run, apart from the handler that could also be notified, so I changed it to only reload when the handler is actually notified.

The extra flushing of handlers was needed, because with only the `flush_handlers` in nginx.yml, Certbot would fail because the kernel's RNG was not seeded yet just after the reboot. So I added a second earlier point where the handlers are flushed, to give the system time to fully complete its reboot before attempting to run Certbot.