### PR TITLE
Remove virtualenv hackery in favor of pip module

### DIFF
--- a/ansible/tasks/backups.yml
+++ b/ansible/tasks/backups.yml
@@ -9,33 +9,12 @@
       - "python3-dev"
       - "libyaml-dev"
 
-  - name: "create awscli virtualenv"
-    shell: "python3 -m venv /opt/awscli"
-    args:
-      creates: "/opt/awscli"
-
-  - name: "install awscli"
-    shell: "source /opt/awscli/bin/activate; pip install awscli"
-    register: "awscli_pip_result"
-    changed_when: "'installed' in awscli_pip_result.stdout"
-
-  - name: "place aws wrapper"
-    template:
-      src: "templates/{{ aws_cli_path }}.j2"
-      dest: "/{{ aws_cli_path }}"
-      mode: "0755"
-    vars:
-      aws_cli_path: "usr/local/bin/aws"
-
-  - name: "create awscli virtualenv"
-    shell: "python3 -m venv /opt/awscli"
-    args:
-      creates: "/opt/awscli"
-
-  - name: "install awscli"
-    shell: "source /opt/awscli/bin/activate; pip install awscli"
-    register: "awscli_pip_result"
-    changed_when: "'installed' in awscli_pip_result.stdout"
+  - name: "create virtualenv if required, install awscli"
+    pip:
+      virtualenv: "/opt/awscli"
+      virtualenv_python: "python3"
+      name: "awscli"
+      state: "latest"
 
   - name: "place aws wrapper"
     template:


### PR DESCRIPTION
Idempotentically ensuring virtualenvs exist is possible by using the `pip` module, hooray. This PR removes duplicate stuff and the shell commands that gave trouble in staging

