### PR TITLE
Make it possible to delete domains from certificate

### DIFF
--- a/ansible/tasks/nginx.yml
+++ b/ansible/tasks/nginx.yml
@@ -119,7 +119,7 @@
     --agree-tos
     --email "domreg@svsticky.nl"
     --keep-until-expiring
-    --expand
+    --cert-name {{ item.name }}
     --webroot
     --webroot-path /var/www/acme-challenges
     --domain {{ item.name }}


### PR DESCRIPTION
This replaces the `--expand` flag in the Certbot task to `--cert-name {{ item.name }}`. For more info, see #162.

Fixes #162.