### PR TITLE
Fix variable bug in Bash scripts

### DIFF
--- a/ansible/scripts/fetch-keys-for-gh-user.sh
+++ b/ansible/scripts/fetch-keys-for-gh-user.sh
@@ -13,7 +13,7 @@ IFS=$'\n\t'
 SADSERVER_DIR="$(git rev-parse --show-toplevel)"
 
 # Check if a minimum of 1 GH username was given
-if [[ -z "${1+x}" ]]; then
+if [[ -z "${1:-}" ]]; then
   >&2 echo "USAGE: fetch-keys-for-gh-user.sh [GITHUB_USERNAME]..."
   exit 1
 fi

--- a/ansible/scripts/run-playbook.sh
+++ b/ansible/scripts/run-playbook.sh
@@ -20,11 +20,7 @@ set -eEfuo pipefail
 
 USAGE="USAGE: $0 <production | staging> <PLAYBOOK_PATH> [<ANSIBLE-PLAYBOOK \
 PARAMETERS>]"
-if [[ -z ${1+x} ]]; then
-  echo "$USAGE"
-  exit 1
-fi
-if [[ -z ${2+x} ]]; then
+if [[ -z ${1:-} || -z ${2:-} ]]; then
   echo "$USAGE"
   exit 1
 fi
@@ -43,8 +39,7 @@ function abort_deploy() {
 
 case ${ENVIRONMENT} in
   production)
-    while [[ -z ${PROD_CHOICE+x} || ${PROD_CHOICE} != "Y" && \
-    ${PROD_CHOICE} != "n" ]]; do
+    while [[ ${PROD_CHOICE:-} != "Y" && ${PROD_CHOICE:-} != "n" ]]; do
       read -p "DO YOU REALLY PLAN TO DEPLOY TO PRODUCTION? [Y/n]: "\
       PROD_CHOICE
     done
@@ -56,8 +51,7 @@ case ${ENVIRONMENT} in
         ;;
     esac
     if [[ ${GIT_BRANCH} != "master" ]]; then
-      while [[ -z ${BRANCH_CHOICE+x} || ${BRANCH_CHOICE} != "Y" && \
-      ${BRANCH_CHOICE} != "n" ]]; do
+      while [[ ${BRANCH_CHOICE:-} != "Y" && ${BRANCH_CHOICE:-} != "n" ]]; do
         read -p "You are deploying to production from a branch other than \
 'master', are you sure? [Y/n]: " \
         BRANCH_CHOICE

--- a/ansible/templates/usr/local/bin/backup-to-s3.sh.j2
+++ b/ansible/templates/usr/local/bin/backup-to-s3.sh.j2
@@ -23,7 +23,7 @@ print_to_stderr() {
   echo >&2 "${1}"
 }
 
-if [[ -z ${1+x} ]]; then
+if [[ -z ${1:-} ]]; then
   print_to_stderr "${USAGE}"
   exit 1
 fi
@@ -40,7 +40,7 @@ cleanup() {
 
   # Check because file extension is only set when a valid backup source is
   # passed
-  if [[ -n ${FILE_EXT+x} ]]; then
+  if [[ -n ${FILE_EXT:-} ]]; then
     {
       rm -rf "{{ tmp_dir }}/${FILE}.${FILE_EXT}"
       rm -rf "{{ tmp_dir }}/${FILE}.${FILE_EXT}.${HASH}"


### PR DESCRIPTION
This fixes a bug in Bash's [parameter substitution] we use in our shell scripts. The old construction would set a variable to the default "x" when the var *was* already set, instead of when it *wasn't* set. Since most of our tests don't use the value, this hasn't had consequences in use. The ":" makes sure the var is also substituted when the var is assigned a null value.

Actually became aware of this because I used the construction in a personal script as well, and it errored because of some race condition 😅 

[parameter substitution]:
https://www.tldp.org/LDP/abs/html/parameter-substitution.html