### PR TITLE
Use Bitwarden CLI to supply Vault passphrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,13 @@ server to become Sticky's production server.
 
 The code in this repository depends on the following software:
 
- - [ansible] >= 2.5
- - [slacktee] -- create the `ansible/.slack-webhook` file with a Slack webhook
-   in order to run the provisioning script.
- - bash
+- [ansible] >= 2.5
+- [slacktee] (vendored) -- create the `ansible/.slack-webhook` file with a
+  Slack webhook in order to run the provisioning script.
+- optionally:
+  - [Bitwarden CLI] (`bw` being available in your `$PATH`)
+  - jq (`jq` being available in your `$PATH`)
+- bash
 
 Furthermore, the Ansible playbooks assume a **vanilla Ubuntu 18.04 host** to be
 deployed on.
@@ -198,6 +201,7 @@ Godspeed!
   [inventory]:https://docs.ansible.com/ansible/intro_inventory.html
   [slacktee]:https://github.com/course-hero/slacktee
   [ansible]:https://github.com/ansible/ansible
+  [Bitwarden CLI]:https://help.bitwarden.com/article/cli/#download--install
   [deployment-new-production]:docs/deployment-new-production.md
   [IT Crowd]:mailto:itcrowd@svsticky.nl
   [deployment-guide]:#setting-up-the-staging-and-production-environment

--- a/ansible/scripts/get-vault-pass-from-bitwarden-client.sh
+++ b/ansible/scripts/get-vault-pass-from-bitwarden-client.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+##
+## USAGE:
+## ./scripts/get-vault-pass-from-bitwarden-client.sh --vault-id <vault id>
+##
+## Dependencies:
+##   - Bitwarden CLI
+##   - jq
+##
+## This script uses Bitwarden's CLI tool to print the Ansible Vault passphrase
+## for the vault id that is passed as an argument, to stdout. Make sure that
+## nothing else is printed to stdout.
+##
+## NOTE: The filename (minus extension) of this script *HAS* to end with
+## "-client". This makes Ansible 2.5+ add the vault id to the invocation of
+## this script. (I did not make that up.)
+##
+
+# Unofficial Bash strict mode
+set -eEfuo pipefail
+
+USAGE="USAGE: $0 --vault-id <vault id>"
+if [[ ${1:-} != "--vault-id" || -z ${2:-} ]]; then
+  echo "${USAGE}" >&2
+  exit 1
+fi
+
+VAULT_ID="${2}"
+
+# Pulls changes from the remote BW vault, which should only fail when the vault
+# is not unlocked yet. If so, it prints an error message that's more helpful
+# than the default one.
+bw sync >/dev/null || { echo \
+  "ERROR: No unlocked Bitwarden vault encountered in environment." \
+  "Please unlock your Bitwarden vault first using \"bw unlock\"." >&2; \
+  exit 1; }
+
+echo "Vault passphrase for ${VAULT_ID} environment:" >&2
+bw get item caa7fb69-913a-4f08-9d0f-a87f013d39d2 \
+  | jq --exit-status --raw-output \
+    ".fields[] | select(.name==\"${VAULT_ID}\") | .value" \
+  || exit 2
+  # Fail with RC of 2 when secret is not found,
+  # because Ansible recognises this.


### PR DESCRIPTION
If available, get the Vault passphrase from the unlocked Bitwarden Vault in the environment, performed using its CLI. If you don't have the Bitwarden CLI installed, it'll prompt as usual.