### PR TITLE
WIP: Update pretix version, add plugins

### DIFF
--- a/ansible/tasks/pretix.yml
+++ b/ansible/tasks/pretix.yml
@@ -87,11 +87,13 @@
     virtualenv_python: "python3.6"
   with_items:
     - name: "gunicorn"
-      version: "19.8.1"
+      version: "19.9.0"
     - name: "pretix[mysql]"
-      version: "1.15.2"
+      version: "2.1.0"
     - name: "pretix-pages"
-      version: "1.2.2"
+      version: "1.2.4"
+    - name: "pretix-mollie"
+      version: "1.0.0"
   register: "pretix_install_result"
   become: true
   become_user: "pretix"

--- a/ansible/tasks/pretix.yml
+++ b/ansible/tasks/pretix.yml
@@ -94,6 +94,8 @@
       version: "1.2.4"
     - name: "pretix-mollie"
       version: "1.0.0"
+    - name: "pretix-fontpack-free"
+      version: "1.0.2.post1"
   register: "pretix_install_result"
   become: true
   become_user: "pretix"

--- a/ansible/tasks/pretix.yml
+++ b/ansible/tasks/pretix.yml
@@ -89,7 +89,7 @@
     - name: "gunicorn"
       version: "19.9.0"
     - name: "pretix[mysql]"
-      version: "2.1.0"
+      version: "2.2.0"
     - name: "pretix-pages"
       version: "1.2.4"
     - name: "pretix-mollie"


### PR DESCRIPTION
It is now possible to use Mollie as a payments provider for Pretix, I think that Execut will want this since it's cheaper. Also adds some new features by adding plugins.