### PR TITLE
Add fail2ban jail for 404's on activities, findtime option

### DIFF
--- a/ansible/templates/etc/fail2ban/filter.d/koala404.conf.j2
+++ b/ansible/templates/etc/fail2ban/filter.d/koala404.conf.j2
@@ -1,0 +1,2 @@
+[Definition]
+failregex = <HOST> .* "GET /activities/\d+ HTTP/\S+" 404

--- a/ansible/templates/etc/fail2ban/jail.local.j2
+++ b/ansible/templates/etc/fail2ban/jail.local.j2
@@ -26,6 +26,9 @@ logpath = {{ service.logpath }}
 {% if service.maxretry is defined %}
 maxretry = {{ service.maxretry }}
 {% endif %}
+{% if service.findtime is defined %}
+findtime = {{ service.findtime }}
+{% endif %}
 {% if service.protocol is defined %}
 protocol = {{ service.protocol }}
 {% endif %}


### PR DESCRIPTION
This PR adds a fail2ban filter and jail for 404's on Koala's activities, as discussed in Slack.

Testable by spamming this in terminal, which should ban you after the fifth 404 within 60 seconds:

```
curl -b 'constipated_koala_session=anlYajZJWFBkcUxRSk8rRkVJWUtlNEVTNFJDZ2ZZMXpGdTRpbFFITS9PbzRnVGVVZm0wbVN5bkcyQ0hDY241dlVhNStyUWRwQ2Vnak5nWllKNHp3Qjd6L09PMFk0R0FRRmNXaU4vV3pkMnpEYXZ0aGUwNzRUYm9WMnpuNjhPcnNxd3JrUzErTnd4WjVPcWNaS2JlMkI5VjhzMXlMV0pvOVJjbFp0NUdIY0ZSOHdHTjdrMmRIVlQxRkFNeDlMbHAxbm9Jb2lpbzNtREdPVkJHaThQYzgxMUVZOGlJeXA0S2dDakNzRDQxMmF4ZG13RVlMcitndHdmbnUwQzd6TC91N0tocG5TbWFHWlBVVVY2V2I0YlB5Rjh5cWxjdjRidnN5eUxrelZHdFV0S3FDeU4yY2svUi9kV0I5elpIWnBqNytLTXBZYnNHRUR1L2doQnVCY1duQjB3PT0tLWQ3a295NlJMZ2dVcWdYdWk5cFpaN3c9PQ%3D%3D--954753f9429be45bab05dd42552ad42878fd4c14' --insecure https://koala.dev.svsticky.nl/activities/123
```