### PR TITLE
Add Referer tracking for Execut websites

### DIFF
--- a/ansible/scripts/csvpseudo.py
+++ b/ansible/scripts/csvpseudo.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Pseudonymize columns in a CSV or TSV file.
+
+Each unique value in the column that is to be pseudonymized is assigned an
+ascending number, which replaces the value in the output. Equal values are
+assigned the same number, also across columns.
+"""
+import argparse
+import csv
+import collections
+import itertools
+import sys
+
+from typing import Any, List, DefaultDict
+
+
+def counter_dict(start: int = 1, step: int = 1) -> DefaultDict[Any, int]:
+    """
+    :return: A defaultdict that assigns each new unseen key an ascending number.
+    :param start: The first number to assign.
+    :param step: The step to add to get the next number.
+    """
+
+    counter = itertools.count(start, step)
+    return collections.defaultdict(lambda: next(counter))
+
+
+def do_pseudonymize(
+    reader: csv.reader,
+    writer: csv.writer,
+    columns: List[int],
+    pseudonyms: DefaultDict[Any, Any],
+) -> None:
+    """
+    Pseudonymize a CSV-like file.
+
+    :param reader: Input reader.
+    :param writer: Output writer.
+    :param columns: Set of indices of columns to pseudonymize.
+    :param pseudonyms: Mapping of values to pseudonyms. Should not raise KeyError if a value has no pseudonym yet.
+    """
+
+    for row in reader:
+        for index in columns:
+            row[index] = pseudonyms[row[index]]
+
+        writer.writerow(row)
+
+
+def main():
+    """ Main script entry point. """
+    # Parse arguments
+    parser = argparse.ArgumentParser(description=__doc__)
+
+    parser.add_argument(
+        "--input",
+        "-i",
+        help="input to read, stdin if omitted.",
+        default=None,
+        nargs="?",
+    )
+
+    parser.add_argument(
+        "columns", nargs="+", type=int, help="column indices (0-based) to pseudonymize."
+    )
+
+    args = parser.parse_args()
+
+    # Open file and determine input format
+    if args.input:
+        infile = open(args.input, "r")
+    else:
+        infile = sys.stdin
+
+    sample = infile.readline()
+    csv_dialect = csv.Sniffer().sniff(sample)
+    infile.seek(0)
+
+    reader = csv.reader(infile, dialect=csv_dialect)
+
+    # Do the pseudonymization
+    pseudonyms = counter_dict()
+
+    writer = csv.writer(sys.stdout, csv_dialect)
+
+    do_pseudonymize(reader, writer, args.columns, pseudonyms)
+
+    # Clean up
+    infile.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible/templates/etc/nginx/includes/execut-referer-tracking.conf.j2
+++ b/ansible/templates/etc/nginx/includes/execut-referer-tracking.conf.j2
@@ -4,3 +4,6 @@
 
 access_log /var/log/nginx/execut_referer_tracking referer_tracking
     if=$do_log_referer;
+
+access_log /var/log/nginx/execut_referer_tracking_optout ip_address
+    if=$tracking_optout;

--- a/ansible/templates/etc/nginx/includes/execut-referer-tracking.conf.j2
+++ b/ansible/templates/etc/nginx/includes/execut-referer-tracking.conf.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+
+# Include to enable Referer logging for Execut. See nginx.conf.
+
+access_log /var/log/nginx/execut_referer_tracking referer_tracking
+    if=$do_log_referer;

--- a/ansible/templates/etc/nginx/nginx.conf.j2
+++ b/ansible/templates/etc/nginx/nginx.conf.j2
@@ -89,8 +89,16 @@ http {
       default 1;
   }
 
+  map $http_dnt $tracking_optout {
+      1 1;
+      0 0;
+      default 0;
+  }
+
   log_format referer_tracking escape=json
-      '$http_referer\t$scheme://$host$request_uri\t$time_iso8601\t$remote_addr';
+      '$http_referer\t$scheme://$host$request_uri\t$time_iso8601\t$remote_addr$http_user_agent';
+
+  log_format ip_address '$remote_addr$http_user_agent';
 
   ##
   # GZip Settings

--- a/ansible/templates/etc/nginx/nginx.conf.j2
+++ b/ansible/templates/etc/nginx/nginx.conf.j2
@@ -72,6 +72,27 @@ http {
   error_log /var/log/nginx/error.log crit;
 
   ##
+  # Execut referer tracking
+  ##
+
+  # Enables logging Referer header to a separate logfile, if the Referer is not
+  # under *.execut.nl AND the HTTP Do-not-track header is absent or set to
+  # allow tracking (0).
+  # Adapted from the docs at:
+  # http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log
+  # Note that this value is only evaluated if the execut-referer-tracking
+  # include is used.
+
+  map $http_dnt$http_referer $do_log_referer {
+      ~^1 0;
+      ~^0?https?:\/\/(.+\.)*execut\.nl 0;
+      default 1;
+  }
+
+  log_format referer_tracking escape=json
+      '$http_referer\t$scheme://$host$request_uri\t$time_iso8601\t$remote_addr';
+
+  ##
   # GZip Settings
   ##
   gzip on;

--- a/ansible/templates/etc/nginx/sites-available/website.conf.j2
+++ b/ansible/templates/etc/nginx/sites-available/website.conf.j2
@@ -19,6 +19,10 @@ item.name }};
 
   include includes/security-headers.conf;
   include includes/php-parameters.conf;
+  {% if item.extra_includes is defined -%}
+  {% for include in item.extra_includes %}include includes/{{ include }}.conf;
+  {% endfor %}
+  {% endif %}
 
   location ~* /.git/ {
     deny all;


### PR DESCRIPTION
Adds logging of Referer headers for visits to the Execut website. Logging is only done if:

1. The Do Not Track header is not enabled (so absent or 0), and
2. The Referer header specifies a referrer not under *.execut.nl (we only care about incoming visits).

All Execut websites log referrers to `/var/log/nginx/execut_referer_tracking` in a Tab-seperated file containing Referer, URL, timestamp and IP. This file needs to be either pseudonymized or anonymized before sharing the data.

Also adds a new website variable `extra_includes` that can be reused to enable includes without creating yet another copy of the website config template.

And yes, Referer is a misspelling, but it is the correct header name: https://en.wikipedia.org/wiki/HTTP_referer

To do:

 - [x] ~~Enable `extra_includes` for Pretix~~ Not relevant because of widget
 - [x] Pseudonymization script
 - [x] ~Legalese for 'hey we collect this' and how to opt out~