### PR TITLE
Add status messages for static-sticky deployments 

### DIFF
--- a/ansible/tasks/packages.yml
+++ b/ansible/tasks/packages.yml
@@ -13,6 +13,7 @@
       - "htop"
       - "unattended-upgrades"
       - "haveged"
+      - "jq"
     state: "present"
 
 - name: "update all packages"

--- a/ansible/tasks/static-sticky.yml
+++ b/ansible/tasks/static-sticky.yml
@@ -14,6 +14,19 @@
   with_items:
     - "/usr/local/bin/deploy-static-sticky.sh"
 
+- name:
+    "install systemd-journal-remote for accessing static-sticky's deploy logs
+    remotely"
+  apt:
+    name: "systemd-journal-remote"
+    state: "present"
+
+- name: "start and enable systemd-journal-gatewayd"
+  systemd:
+    name: "systemd-journal-gatewayd"
+    enabled: true
+    state: "started"
+
 - block:
   - name:
       "clone static-sticky repository"

--- a/ansible/templates/etc/nginx/sites-available/svsticky.conf.j2
+++ b/ansible/templates/etc/nginx/sites-available/svsticky.conf.j2
@@ -64,6 +64,11 @@ server {
     return 301 https://docs.google.com/forms/d/e/1FAIpQLSdBPZtXKmqW8Pbo3M7cDyvxu0O-JInHxLF4Q3jXWrKnzAX8pA/viewform;
   }
 
+  location /logs {
+    rewrite /logs/(.+) /entries?_SYSTEMD_INVOCATION_ID=$1 break;
+    proxy_pass http://localhost:19531;
+  }
+
   location / {
     try_files $uri $uri/ =404;
   }

--- a/ansible/templates/etc/systemd/system/deploy-static-sticky.service.j2
+++ b/ansible/templates/etc/systemd/system/deploy-static-sticky.service.j2
@@ -2,7 +2,6 @@
 
 [Unit]
 Description=Deploy static-sticky
-OnFailure=failure-notificator@%n.service
 
 [Service]
 Type=oneshot

--- a/ansible/templates/etc/systemd/system/deploy-static-sticky.service.j2
+++ b/ansible/templates/etc/systemd/system/deploy-static-sticky.service.j2
@@ -7,4 +7,5 @@ Description=Deploy static-sticky
 Type=oneshot
 User=static-sticky
 Group=static-sticky
+PrivateTmp=yes
 ExecStart=/usr/local/bin/deploy-static-sticky.sh

--- a/ansible/templates/usr/local/bin/deploy-static-sticky.sh.j2
+++ b/ansible/templates/usr/local/bin/deploy-static-sticky.sh.j2
@@ -21,6 +21,7 @@ fail_github_deploy_status() {
     --request POST \
     --data \
       '{"state": "failure",
+        "environment_url": "https://{{ canonical_hostname }}/",
         "log_url": "https://{{ canonical_hostname }}/logs/'"${INVOCATION_ID}"'"
       }' \
     "https://api.github.com/repos/svsticky/static-sticky/deployments/${DEPLOY_ID}/statuses"
@@ -89,6 +90,7 @@ curl \
   --request POST \
   --data \
     '{"state": "success",
+      "environment_url": "https://{{ canonical_hostname }}/",
       "log_url": "https://{{ canonical_hostname }}/logs/'"${INVOCATION_ID}"'"
     }' \
   "https://api.github.com/repos/svsticky/static-sticky/deployments/${DEPLOY_ID}/statuses"

--- a/ansible/templates/usr/local/bin/deploy-static-sticky.sh.j2
+++ b/ansible/templates/usr/local/bin/deploy-static-sticky.sh.j2
@@ -16,10 +16,13 @@ fail_github_deploy_status() {
     --output /dev/null \
     --fail \
     --user "${GITHUB_USER}:${GITHUB_PASSWORD}" \
-    --header "Accept: application/vnd.github.v3+json" \
+    --header "Accept: application/vnd.github.ant-man-preview+json" \
     --header "Content-Type: application/json" \
     --request POST \
-    --data '{"state": "failure"}' \
+    --data \
+      '{"state": "failure",
+        "log_url": "https://{{ canonical_hostname }}/logs/'"${INVOCATION_ID}"'"
+      }' \
     "https://api.github.com/repos/svsticky/static-sticky/deployments/${DEPLOY_ID}/statuses"
 }
 
@@ -81,8 +84,11 @@ curl \
   --output /dev/null \
   --fail \
   --user "${GITHUB_USER}:${GITHUB_PASSWORD}" \
-  --header "Accept: application/vnd.github.v3+json" \
+  --header "Accept: application/vnd.github.ant-man-preview+json" \
   --header "Content-Type: application/json" \
   --request POST \
-  --data '{"state": "success"}' \
+  --data \
+    '{"state": "success",
+      "log_url": "https://{{ canonical_hostname }}/logs/'"${INVOCATION_ID}"'"
+    }' \
   "https://api.github.com/repos/svsticky/static-sticky/deployments/${DEPLOY_ID}/statuses"

--- a/ansible/templates/usr/local/bin/deploy-static-sticky.sh.j2
+++ b/ansible/templates/usr/local/bin/deploy-static-sticky.sh.j2
@@ -5,14 +5,58 @@
 set -efuo pipefail
 IFS=$'\n\t'
 
+GITHUB_USER="svsticky-deploy"
+GITHUB_PASSWORD="{{ secret_static_sticky.github_deployments_token }}"
+DEPLOY_ENV="{{ ('staging' in group_names) | ternary("staging", "production") }}"
+
+fail_github_deploy_status() {
+  # Create a "deployment status" at GitHub: "failure"
+  curl \
+    --silent --show-error \
+    --output /dev/null \
+    --fail \
+    --user "${GITHUB_USER}:${GITHUB_PASSWORD}" \
+    --header "Accept: application/vnd.github.v3+json" \
+    --header "Content-Type: application/json" \
+    --request POST \
+    --data '{"state": "failure"}' \
+    "https://api.github.com/repos/svsticky/static-sticky/deployments/${DEPLOY_ID}/statuses"
+}
+
 cd /var/www/static-sticky/static-sticky
 
 git reset --hard HEAD
 
-PREV_GIT_REF="$(git rev-parse HEAD)"
+PREV_GIT_REF="$(git rev-parse --short HEAD)"
 # Get latest version of website sourcecode
 git pull origin {{ static_sticky_env.git_ref }}
-NEW_GIT_REF="$(git rev-parse HEAD)"
+NEW_GIT_REF="$(git rev-parse --short HEAD)"
+
+if [[ "${PREV_GIT_REF}" != "${NEW_GIT_REF}" ]]; then
+  DEPLOY_DESCRIPTION="Deploying commit ${NEW_GIT_REF} on top of ${OLD_GIT_REF}."
+else
+  DEPLOY_DESCRIPTION="Deploying new changes from Contentful."
+fi
+
+# Create a "deployment" at GitHub and save its ID
+DEPLOY_ID="$(curl \
+  --silent --show-error \
+  --fail \
+  --user "${GITHUB_USER}:${GITHUB_PASSWORD}" \
+  --header "Accept: application/vnd.github.v3+json" \
+  --header "Content-Type: application/json" \
+  --request POST \
+  --data \
+    '{"ref": "'"${NEW_GIT_REF}"'",
+      "auto_merge": false,
+      "required_context": [],
+      "description": "'"${DEPLOY_DESCRIPTION}"'",
+      "environment": "'"${DEPLOY_ENV}"'"
+    }' \
+  https://api.github.com/repos/svsticky/static-sticky/deployments \
+  | jq --raw-output '.id')"
+
+trap fail_github_deploy_status ERR
 
 source /var/www/static-sticky/.nvm/nvm.sh
 
@@ -28,5 +72,17 @@ npm run build
 
 # Copy website contents to webroot, replacing already existing target contents
 rsync --delete --recursive \
-    /var/www/static-sticky/static-sticky/public/ \
-    /var/www/static-sticky/static.{{ canonical_hostname }}/
+  /var/www/static-sticky/static-sticky/public/ \
+  /var/www/static-sticky/static.{{ canonical_hostname }}/
+
+# Create a "deployment status" at GitHub: "success"
+curl \
+  --silent --show-error \
+  --output /dev/null \
+  --fail \
+  --user "${GITHUB_USER}:${GITHUB_PASSWORD}" \
+  --header "Accept: application/vnd.github.v3+json" \
+  --header "Content-Type: application/json" \
+  --request POST \
+  --data '{"state": "success"}' \
+  "https://api.github.com/repos/svsticky/static-sticky/deployments/${DEPLOY_ID}/statuses"


### PR DESCRIPTION
This adds a few calls to GitHub's [Deployments API](https://developer.github.com/v3/repos/deployments/), to allow insight into deployments of the website. Most importantly, this generates webhook events that can be consumed by GitHub's Slack app, so it posts messages in a Slack channel of the CommIT's choosing.

This also creates a deployments overview on GitHub, as in the example [here](https://github.com/zeit/docs/deployments). Different from there, I used the "deployed" link ( `log_url`) to link to the log output of the build. This allows the CommIT to see what went wrong, in case a deploy has failed.

This means the build log is public, but I think that's ok? If not, we could add Basic Auth to the logs directory.

If the CommIT finds this useful, I'll finish it up by adding the access token for our `svsticky-deploy` GitHub user.

Fixes #216.