### PR TITLE
Add setup for Telegram bot for Crazy 88

### DIFF
--- a/ansible/handlers/main.yml
+++ b/ansible/handlers/main.yml
@@ -70,3 +70,10 @@
   systemd:
     unit: "aas.service"
     state: "restarted"
+
+- name: "restart crazy88bot"
+  systemd:
+    unit: "crazy88bot.service"
+    state: "restarted"
+  when: "'production' in group_names"
+

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -48,6 +48,8 @@
       include_tasks: "tasks/static-sticky.yml"
     - name: "start process of configuring aas"
       include_tasks: "tasks/aas.yml"
+    - name: "start process of configuring crazy88bot"
+      include_tasks: "tasks/crazy88bot.yml"
 
   post_tasks:
     # Included the last, so any service that fail2ban is applied to, already

--- a/ansible/tasks/crazy88bot.yml
+++ b/ansible/tasks/crazy88bot.yml
@@ -6,20 +6,33 @@
     home: "/var/lib/crazy88bot"
     system: true
 
-- name: "clone crazy88bot repo"
-  git:
-    repo: "git@github.com:svsticky/crazy88bot.git"
-    dest: "/var/lib/crazy88bot/crazy88bot"
-    key_file: "/home/ansible/.ssh/deploy_ed25519"
-    version: "master"
-  diff: false
-  notify: "restart crazy88bot"
+- block:
+  - name: "ensure crazy88bot has a ssh directory"
+    file:
+      path: "~/.ssh"
+      state: "directory"
 
-- name: "ensure dependencies are installed"
-  pip:
-    requirements: "/var/lib/crazy88bot/crazy88bot/requirements.txt"
-    virtualenv: "/var/lib/crazy88bot/crazy88bot/env"
-    virtualenv_python: "python3.6"
+  - name: "copy deploy key (private) for user crazy88bot"
+    copy:
+      content: "{{ secret_deploy_key }}"
+      dest: "/var/lib/crazy88bot/.ssh/id_ed25519"
+      mode: "0600"
+
+  - name: "clone crazy88bot repo"
+    git:
+      repo: "git@github.com:svsticky/crazy88bot.git"
+      dest: "/var/lib/crazy88bot/crazy88bot"
+      key_file: "/var/lib/crazy88bot/.ssh/id_ed25519"
+      version: "master"
+    diff: false
+    notify: "restart crazy88bot"
+
+  - name: "ensure dependencies are installed"
+    pip:
+      requirements: "/var/lib/crazy88bot/crazy88bot/requirements.txt"
+      virtualenv: "/var/lib/crazy88bot/crazy88bot/env"
+      virtualenv_python: "python3.6"
+
   become_user: "crazy88bot"
 
 - name: "copy systemd service for crazy88bot"

--- a/ansible/tasks/crazy88bot.yml
+++ b/ansible/tasks/crazy88bot.yml
@@ -1,0 +1,40 @@
+---
+- name: "ensure crazy88bot user is present"
+  user:
+    name: "crazy88bot"
+    shell: "/usr/sbin/nologin"
+    home: "/var/lib/crazy88bot"
+    system: true
+
+- name: "clone crazy88bot repo"
+  git:
+    repo: "git@github.com:svsticky/crazy88bot.git"
+    dest: "/var/lib/crazy88bot/crazy88bot"
+    key_file: "/home/ansible/.ssh/deploy_ed25519"
+    version: "master"
+  diff: false
+  notify: "restart crazy88bot"
+
+- name: "ensure dependencies are installed"
+  pip:
+    requirements: "/var/lib/crazy88bot/crazy88bot/requirements.txt"
+    virtualenv: "/var/lib/crazy88bot/crazy88bot/env"
+    virtualenv_python: "python3.6"
+  become_user: "crazy88bot"
+
+- name: "copy systemd service for crazy88bot"
+  template:
+    src: "templates/etc/systemd/system/crazy88bot.service.j2"
+    dest: "/etc/systemd/system/crazy88bot.service"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  notify: "restart crazy88bot"
+
+- name: "start and enable crazy88bot.service in production"
+  systemd:
+    unit: "crazy88bot.service"
+    state: "started"
+    enabled: true
+    daemon-reload: true
+  when: "'production' in group_names"

--- a/ansible/tasks/crazy88bot.yml
+++ b/ansible/tasks/crazy88bot.yml
@@ -1,11 +1,4 @@
 ---
-- name: "ensure crazy88bot user is present"
-  user:
-    name: "crazy88bot"
-    shell: "/usr/sbin/nologin"
-    home: "/var/lib/crazy88bot"
-    system: true
-
 - block:
   - name: "ensure crazy88bot has a ssh directory"
     file:

--- a/ansible/tasks/users.yml
+++ b/ansible/tasks/users.yml
@@ -26,7 +26,7 @@
 
 - name: "fix permissions for chroot of committee users"
   file:
-    path: "/var/www/{{ item.name }}"
+    path: "{{ item.home_prefix }}/{{ item.name }}"
     owner: "root"
     state: "directory"
   when:

--- a/ansible/templates/etc/systemd/system/crazy88bot.service.j2
+++ b/ansible/templates/etc/systemd/system/crazy88bot.service.j2
@@ -1,0 +1,26 @@
+# {{ ansible_managed }}
+
+[Unit]
+Description=Run the Crazy 88 bot
+After=network.target
+OnFailure=failure-notificator@%n.service
+
+[Service]
+Type=simple
+User=crazy88bot
+Group=crazy88bot
+Restart=always
+
+WorkingDirectory=/var/lib/crazy88bot/crazy88bot
+ExecStart=/var/lib/crazy88bot/crazy88bot/env/bin/python main.py
+
+# Sandboxing
+ProtectSystem=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/templates/usr/local/bin/backup-to-s3.sh.j2
+++ b/ansible/templates/usr/local/bin/backup-to-s3.sh.j2
@@ -85,6 +85,8 @@ case "${SOURCE}" in
             --exclude='var/www/sodi.{{ canonical_hostname }}' \
             --exclude='var/www/pretix/venv' \
             -c -f - -C / var/www \
+            var/lib/crazy88bot/crazy88bot/data \
+            var/lib/crazy88bot/crazy88bot/submissions \
             | gzip -9)
           ;;
         databases)


### PR DESCRIPTION
@Phavion (Niels Kwadijk) made a bot that is to be used during the introduction for running the Crazy 88 challenge and accepting submissions from teams via Telegram.

This PR adds a section to the playbook that adds a user for the bot, clones the code, creates a venv, and starts and enables a systemd service for it when running in production.