### PR TITLE
Koala sidekiq changes

### DIFF
--- a/ansible/playbooks/koala/.maintenance-off.yml
+++ b/ansible/playbooks/koala/.maintenance-off.yml
@@ -6,6 +6,13 @@
   become: true
   become_user: "root"
 
+- name: "ensure sidekiq background worker is running"
+  service:
+    name: "sidekiq"
+    state: "started"
+  become: true
+  become_user: "root"
+
 - name: "disable Koala's maintenance mode"
   file:
     state: "absent"

--- a/ansible/playbooks/koala/.maintenance-on.yml
+++ b/ansible/playbooks/koala/.maintenance-on.yml
@@ -5,6 +5,13 @@
   become: true
   become_user: "koala"
 
+- name: "ensure sidekiq background worker is not running"
+  service:
+    name: "sidekiq"
+    state: "stopped"
+  become: true
+  become_user: "root"
+
 - name: "ensure koala is not running"
   service:
     name: "koala"

--- a/ansible/tasks/koala.yml
+++ b/ansible/tasks/koala.yml
@@ -456,7 +456,6 @@
     - "koala-check-study-year.timer"
     - "koala-clean-users-table.timer"
     - "koala-reindex-search.timer"
-    - "sidekiq.service"
 
 - name: "ensure koala update marker is absent"
   file:

--- a/ansible/templates/etc/systemd/system/sidekiq.service.j2
+++ b/ansible/templates/etc/systemd/system/sidekiq.service.j2
@@ -10,7 +10,7 @@ After=syslog.target network.target redis-server.service
 Type=simple
 User=koala
 WorkingDirectory=/var/www/koala.{{ canonical_hostname }}
-ExecStart=/home/koala/.rbenv/shims/bundle exec sidekiq -e {{ koala_env.environment }}
+ExecStart=/home/koala/.rbenv/shims/bundle exec sidekiq -e {{ koala_env.environment }} -q default -q mailers
 
 # if we crash, restart
 RestartSec=1


### PR DESCRIPTION
This PR:
- Alters the template for `sidekiq.service` to include the queues to process jobs
  for, which should fix the problem we have where mails aren't being sent,
- Alters `koala.yml` to remove `sidekiq.service` from the list of timers to only run
  in production, and
- Alters Koala's maintenance mode playbooks to also stop and start `sidekiq.service`
  as appropriate, to ensure that no background jobs can be run while maintenance mode
  is active.