### PR TITLE
Automatically run `run-playbook.sh` in the Nix environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ group_vars/production/vault.yml` (search for
 `vault_slack_notifications_webhook_url`).
 
 1. Bootstrap the host for either production or staging.
-`$ nix run -c ./scripts/run-playbook.sh (production|staging) bootstrap-new-host.yml`
+`$ ./scripts/run-playbook.sh (production|staging) bootstrap-new-host.yml`
 You do not need to enter a SUDO password, but you do need to enter the correct Vault password. (Can usually be found in bitwarden).
 At the end of the process you will receive a newly generated SUDO password, which you will need in the next step. (Save this in bitwarden for future reference).
 On staging, if the playbook fails immediately, you might have an old ssh key. To solve this type:
@@ -183,13 +183,13 @@ On staging, if the playbook fails immediately, you might have an old ssh key. To
 SSH will guide you the rest of the way.
 
 1. Run the main playbook for either production or staging.
-`$ nix run -c ./scripts/run-playbook.sh (production|staging) main.yml`
+`$ ./scripts/run-playbook.sh (production|staging) main.yml`
 Enter the password from the previous step when prompted for.
 
 
 1. To create a new database and start Koala, you will also need to run these two playbooks.
-`$ nix run -c ./scripts/run-playbook.sh (production|staging) playbooks/koala/db-setup.yml`
-`$ nix run -c ./scripts/run-playbook.sh (production|staging) playbooks/koala/start.yml`
+`$ ./scripts/run-playbook.sh (production|staging) playbooks/koala/db-setup.yml`
+`$ ./scripts/run-playbook.sh (production|staging) playbooks/koala/start.yml`
 
 
 ## Contact

--- a/ansible/scripts/get-vault-pass-from-bitwarden-client.sh
+++ b/ansible/scripts/get-vault-pass-from-bitwarden-client.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash ../shell.nix
 
 ##
 ## USAGE:

--- a/ansible/scripts/mariadb-root-tunnel.sh
+++ b/ansible/scripts/mariadb-root-tunnel.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash ../shell.nix
 
 ## This is a small wrapper script that exposes a local socket you can use to
 ## login to a remote MariaDB server. You need this, when:

--- a/ansible/scripts/run-playbook.sh
+++ b/ansible/scripts/run-playbook.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash ../shell.nix
 
 ##
 ## USAGE: ./scripts/run-playbook.sh <production | staging> <PLAYBOOK_PATH>

--- a/ansible/scripts/slacktee.sh
+++ b/ansible/scripts/slacktee.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-
+# This file doesn't get the nix-shell shebang we have for the other scripts in
+# the Ansible repo, because we copy it to the server and run it there as well.
 
 # https://github.com/course-hero/slacktee
 # ------------------------------------------------------------

--- a/ansible/shell.nix
+++ b/ansible/shell.nix
@@ -1,0 +1,18 @@
+# This file determines the environment you get when `nix-shell` is run.
+# We want this to be the same as when running `nix run -c`, so we add some
+# boilerplate:
+let
+  # Import nixpkgs
+  sources = import ./nix/sources.nix {};
+  pkgs = import sources.nixpkgs {};
+
+  # Import whatever's in `default.nix`
+  env = import ./default.nix {};
+
+# Make a shell that makes that the only build input
+in pkgs.mkShell { buildInputs = [ env ]; }
+
+# We can use this file to run shell scripts in the same environment by adding
+# the following shebang lines:
+#!/usr/bin/env nix-shell
+#!nix-shell -i INTERPRETER [relative path to shell.nix]


### PR DESCRIPTION
This PR alters the scripts we use to run the playbook (mainly `run-playbook.sh`) to automatically run in the Nix-managed environment via `nix-shell` as a shebang.