### PR TITLE
Move aas to a Nix-based deployment method

### DIFF
--- a/ansible/tasks/aas.yml
+++ b/ansible/tasks/aas.yml
@@ -1,8 +1,4 @@
 ---
-- name: "install pipenv"
-  pip:
-    name: "pipenv"
-
 - name: "add aas user"
   user:
     name: "aas"
@@ -23,7 +19,7 @@
     git:
       repo: "https://github.com/svsticky/aas.git"
       dest: "/var/www/aas/aas.{{ canonical_hostname }}"
-      version: "ubuntu20"
+      version: "maartenberg/nixdgetspinner"
     diff: false
     register: "aas_clone"
 
@@ -34,12 +30,10 @@
       dest: "/var/www/aas/aas.{{ canonical_hostname }}/.env"
     notify: "restart aas"
 
-  - name: "pipenv create virtual env and install aas"
-    command: "pipenv sync"
+  - name: "create Nix 'virtualenv' with dependencies"
+    command: "nix-build -o .venv"
     args:
       chdir: "/var/www/aas/aas.{{ canonical_hostname }}"
-    environment:
-      PIPENV_VENV_IN_PROJECT: "1"
     when: "aas_clone is changed"
     notify: "restart aas"
 

--- a/ansible/templates/etc/systemd/system/aas.service.j2
+++ b/ansible/templates/etc/systemd/system/aas.service.j2
@@ -16,9 +16,8 @@ WorkingDirectory=/var/www/aas/aas.{{ canonical_hostname }}
 RuntimeDirectory=aas
 RuntimeDirectoryMode=0770
 
-ExecStart=/usr/local/bin/pipenv run gunicorn \
-                                      --workers 4 \
-                                      --bind unix:/run/aas/gunicorn.sock aas:aas
+ExecStart=/var/www/aas/aas.{{ canonical_hostname }}/.venv/bin/gunicorn \
+  --workers 4 --bind unix:/run/aas/gunicorn.sock aas:aas
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/templates/etc/systemd/system/aas.service.j2
+++ b/ansible/templates/etc/systemd/system/aas.service.j2
@@ -16,6 +16,8 @@ WorkingDirectory=/var/www/aas/aas.{{ canonical_hostname }}
 RuntimeDirectory=aas
 RuntimeDirectoryMode=0770
 
+EnvironmentFile=/var/www/aas/aas.{{ canonical_hostname }}/.env
+
 ExecStart=/var/www/aas/aas.{{ canonical_hostname }}/.venv/bin/gunicorn \
   --workers 4 --bind unix:/run/aas/gunicorn.sock aas:aas
 


### PR DESCRIPTION
Companion PR to svsticky/aas#5.
This is already deployed since the last version was broken, after the Aas PR is merged we should update the branch to point to `master` again.