### PR TITLE
Outline production ready

### DIFF
--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -20,6 +20,8 @@
       tags: "pretix"
     - role: "koala"
       tags: "koala"
+    - role: "outline"
+      tags: "outline"
 
   tasks:
     - name: "start process of managing general system settings"

--- a/ansible/roles/outline/tasks/main.yml
+++ b/ansible/roles/outline/tasks/main.yml
@@ -36,11 +36,26 @@
 
 - name: "create environment file"
   template:
-    src: "etc/outline/outline.env.j2"
+    src: "outline.env.j2"
     dest: "/etc/outline/outline.env"
     owner: "root"
     mode: "0600"
   register: "_outline_env_file"
+
+- name: "add apt key for yarn repository"
+  apt_key:
+    url: "https://dl.yarnpkg.com/debian/pubkey.gpg"
+    state: "present"
+
+- name: "add yarn repository"
+  apt_repository:
+    repo: "deb https://dl.yarnpkg.com/debian/ stable main"
+    state: "present"
+
+- name: "install yarn"
+  apt:
+   name: "yarn"
+   state: "present"
 
 - name: "do Yarn stuff"
   become_user: "outline"
@@ -66,7 +81,7 @@
 
 - name: "install Systemd service"
   template:
-    src: "etc/systemd/system/outline.service.j2"
+    src: "outline.service.j2"
     dest: "/etc/systemd/system/outline.service"
     owner: "root"
     mode: "0644"

--- a/ansible/roles/outline/templates/outline.env.j2
+++ b/ansible/roles/outline/templates/outline.env.j2
@@ -42,9 +42,18 @@ AWS_S3_ACL=private
 
 # –––––––––––––– AUTHENTICATION ––––––––––––––
 
-KOALA_CLIENT_ID={{ secret_oauth2_proxy.client_id }}
-KOALA_CLIENT_SECRET={{ secret_oauth2_proxy.client_secret }}
-KOALA_CLIENT_URL=https://koala.{{ canonical_hostname }}
+
+OIDC_CLIENT_ID={{ secret_oauth2_proxy.client_id }}
+OIDC_CLIENT_SECRET={{ secret_oauth2_proxy.client_secret }}
+OIDC_AUTH_URI=https://koala.{{ canonical_hostname }}/api/oauth/authorize
+OIDC_TOKEN_URI=https://koala.{{ canonical_hostname }}/api/oauth/token
+OIDC_USERINFO_URI=https://koala.{{ canonical_hostname }}/oauth/userinfo
+
+# Display name for OIDC authentication
+OIDC_DISPLAY_NAME=Koala Oauth
+
+# Space separated auth scopes.
+OIDC_SCOPES=openid profile email member-read
 
 # –––––––––––––––– OPTIONAL ––––––––––––––––
 
@@ -61,6 +70,10 @@ FORCE_HTTPS=true
 # Have the installation check for updates by sending anonymized statistics to
 # the maintainers
 ENABLE_UPDATES=true
+
+# How many processes should be spawned. As a reasonable rule divide your servers
+# available memory by 512 for a rough estimate
+WEB_CONCURRENCY=1
 
 # Override the maxium size of document imports, could be required if you have
 # especially large Word documents with embedded imagery

--- a/ansible/roles/outline/templates/outline.service.j2
+++ b/ansible/roles/outline/templates/outline.service.j2
@@ -4,7 +4,7 @@ Wants=redis.service postgresql.service
 
 [Service]
 ExecStartPre=/usr/bin/yarn db:migrate
-ExecStart=/usr/bin/yarn start
+ExecStart=/usr/bin/yarn start --env production
 WorkingDirectory=/var/www/outline/outline
 
 EnvironmentFile=/etc/outline/outline.env


### PR DESCRIPTION
Updates Outline to 0.59.0 and a new oauth method supplied by outline. Decreases the amount of threads so it doesn't consume the entire server