### PR TITLE
Upgrade `bw` version

### DIFF
--- a/ansible/default.nix
+++ b/ansible/default.nix
@@ -4,6 +4,7 @@
 
 let
   pkgs = import sources.nixpkgs {};
+  pkgs-new = import sources.nixpkgs-unstable {};
 
   python = pkgs.python37;
 
@@ -23,7 +24,7 @@ in pkgs.buildEnv {
   name = "sadserver-environment";
   paths = [
     pythonEnvironment
-    pkgs.bitwarden-cli
+    pkgs-new.bitwarden-cli
     pkgs.jq
     pkgs.yamllint
   ];

--- a/ansible/default.nix
+++ b/ansible/default.nix
@@ -16,7 +16,6 @@ let
     pkgs.click
     pkgs.mypy
     pkgs.GitPython
-    pkgs.ansible-lint
     ansible-mitogen
   ]);
 
@@ -25,6 +24,7 @@ in pkgs.buildEnv {
   paths = [
     pythonEnvironment
     pkgs-new.bitwarden-cli
+    pkgs.ansible-lint
     pkgs.jq
     pkgs.yamllint
   ];

--- a/ansible/nix/sources.json
+++ b/ansible/nix/sources.json
@@ -22,5 +22,17 @@
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/6d4b93323e7f78121f8d6db6c59f3889aa1dd931.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "nixpkgs-unstable": {
+        "branch": "nixpkgs-unstable",
+        "description": "Nix Packages collection",
+        "homepage": "",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c11d08f02390aab49e7c22e6d0ea9b176394d961",
+        "sha256": "017jdga9j0qkdplly8pypxxcsski0h9galzaf9qsvpq0j50x86cv",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c11d08f02390aab49e7c22e6d0ea9b176394d961.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This PR alters the Nix config to

 - Add a new source `nixpkgs-new` to `niv` that pins the latest unstable Nixpkgs,
 - Alter the Nix environment to get `bw` from this Nixpkgs snapshot, to use the newest version (1.19.1) instead of the currently-pinned version that can't log in anymore,
 - Alter the Nix environment to move `ansible-lint` out of the Python environment to prevent future problems when upgrading Ansible.

With this PR I can `nix run -c bw login` again.