### PR TITLE
Require postgres in servicefile instead of mysql

### DIFF
--- a/ansible/roles/koala/templates/systemd/koala.service.j2
+++ b/ansible/roles/koala/templates/systemd/koala.service.j2
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=Run koala {{ koala_env.environment }} service
-Wants=mysql.service
+Wants=postgresql.service
 After=network.target
 OnFailure=failure-notificator@%n.service
 

--- a/ansible/roles/pretix/templates/systemd/pretix-runperiodic.service.j2
+++ b/ansible/roles/pretix/templates/systemd/pretix-runperiodic.service.j2
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=Clear expired pretix sessions
-Requires=mysql.service
+Requires=postgresql.service
 OnFailure=failure-notificator@%n.service
 
 [Service]


### PR DESCRIPTION
I came across this when writing a PR to cleanup mysql (see #232).
This should be an easy deploy, but I'm waiting for a work session to perform it as it takes a little downtime.