### PR TITLE
update oauth2proxy systemd templates

### DIFF
--- a/ansible/roles/oauth2_proxy/templates/oauth2-proxy-admin.service.j2
+++ b/ansible/roles/oauth2_proxy/templates/oauth2-proxy-admin.service.j2
@@ -6,7 +6,7 @@ OnFailure=failure-notificator@%n.service
 
 [Service]
 Restart=always
-ExecStart=/usr/local/bin/oauth2_proxy -config /etc/oauth2_proxy/admin-config.cfg
+ExecStart=/usr/local/bin/oauth2-proxy -config /etc/oauth2_proxy/admin-config.cfg
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/oauth2_proxy/templates/oauth2-proxy.service.j2
+++ b/ansible/roles/oauth2_proxy/templates/oauth2-proxy.service.j2
@@ -6,7 +6,7 @@ OnFailure=failure-notificator@%n.service
 
 [Service]
 Restart=always
-ExecStart=/usr/local/bin/oauth2_proxy -config /etc/oauth2_proxy/config.cfg
+ExecStart=/usr/local/bin/oauth2-proxy -config /etc/oauth2_proxy/config.cfg
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
In #370 I kinda updated the proxy, but didn't realize the executable name changed from `oauth2_proxy` to `oauth2-proxy`.
This PR fixes the oversight and closes #352 