### PR TITLE
staging certificates when host is staging

### DIFF
--- a/ansible/roles/certbot/tasks/main.yml
+++ b/ansible/roles/certbot/tasks/main.yml
@@ -55,6 +55,9 @@
   command: >-
     certbot certonly
     --non-interactive
+    {% if 'staging' in group_names %}
+    --test-cert
+    {% endif %}
     --agree-tos
     --email "domreg@svsticky.nl"
     --keep-until-expiring

--- a/ansible/roles/freight/tasks/main.yml
+++ b/ansible/roles/freight/tasks/main.yml
@@ -52,6 +52,9 @@
   command: >-
     certbot certonly
     --non-interactive
+    {% if 'staging' in group_names %}
+    --test-cert
+    {% endif %}
     --agree-tos
     --email "domreg@svsticky.nl"
     --keep-until-expiring


### PR DESCRIPTION
Note, that the staging *root* certificates have to be manually imported to the browser. I do not know quite yet how to do so, as I cannot find the private key which is used to generate the certificates - which firefox claims to require.

More info: https://letsencrypt.org/docs/staging-environment/