### PR TITLE
Remove all execut.nl subdomains

### DIFF
--- a/ansible/group_vars/all/websites.yml
+++ b/ansible/group_vars/all/websites.yml
@@ -97,7 +97,6 @@ websites:
     custom_config: true
     alternative_names:
       - "tickets.{{ canonical_hostname }}"
-      - "tickets.execut.nl"
     state: "present"
 
   - name: "radio.{{ canonical_hostname }}"
@@ -180,68 +179,56 @@ websites:
 
   - name: "execut-speakers.{{ canonical_hostname }}"
     user: "symposium"
-    alternative_names:
-      - "speakers.execut.nl"
+    alternative_names: []
     extra_includes:
       - "execut-referer-tracking"
     state: "present"
 
   - name: "execut-partners.{{ canonical_hostname }}"
     user: "symposium"
-    alternative_names:
-      - "partners.execut.nl"
+    alternative_names: []
     extra_includes:
       - "execut-referer-tracking"
     state: "absent"
 
   - name: "execut-survey.{{ canonical_hostname }}"
     user: "symposium"
-    alternative_names:
-      - "survey.execut.nl"
+    alternative_names: []
     extra_includes:
       - "execut-referer-tracking"
     state: "present"
 
   - name: "execut-landing.{{ canonical_hostname }}"
     user: "symposium"
-    alternative_names:
-      - "landing.execut.nl"
+    alternative_names: []
     extra_includes:
      - "execut-referer-tracking"
     state: "present"
 
   - name: "execut-2018.{{ canonical_hostname }}"
     user: "symposium"
-    alternative_names:
-      - "2018.execut.nl"
+    alternative_names: []
     extra_includes:
       - "execut-referer-tracking"
     state: "present"
 
   - name: "execut-2019.{{ canonical_hostname }}"
     user: "symposium"
-    alternative_names:
-      - "2019.execut.nl"
+    alternative_names: []
     extra_includes:
       - "execut-referer-tracking"
     state: "present"
 
   - name: "execut-2020.{{ canonical_hostname }}"
     user: "symposium"
-    alternative_names:
-      - "2020.execut.nl"
+    alternative_names: []
     extra_includes:
       - "execut-referer-tracking"
     state: "present"
 
-  - name: "execut-2023.{{ canonical_hostname}}"
+  - name: "execut-2023.{{ canonical_hostname }}"
     user: "symposium"
-    alternative_names:
-      - "2023.execut.nl"
-      - "www.execut.nl"
-      - "execut.nl"
-      - "www.execute.nl"
-      - "execute.nl"
+    alternative_names: []
     extra_includes:
       - "execut-referer-tracking"
     custom_config: true
@@ -249,25 +236,21 @@ websites:
 
   - name: "execut-aftermovie.{{ canonical_hostname }}"
     user: "symposium"
-    alternative_names:
-      - "aftermovie.execut.nl"
+    alternative_names: []
     extra_includes:
       - "execut-referer-tracking"
     state: "present"
 
   - name: "execut-app.{{ canonical_hostname }}"
     user: "symposium"
-    alternative_names:
-      - "app.execut.nl"
+    alternative_names: []
     extra_includes:
       - "execut-referer-tracking"
     state: "absent"
 
   - name: "execut-2021.{{ canonical_hostname }}"
     user: "symposium"
-    alternative_names:
-      - "2021.execut.nl"
-      - "2022.execut.nl"
+    alternative_names: []
     extra_includes: []
     custom_config: true
     state: "present"
@@ -299,14 +282,12 @@ websites:
 
   - name: "execut-feedback.{{ canonical_hostname }}"
     user: "symposium"
-    alternative_names:
-      - "feedback.execut.nl"
+    alternative_names: []
     state: "present"
 
   - name: "execut-qa.{{ canonical_hostname }}"
     user: "symposium"
-    alternative_names:
-      - "qa.execut.nl"
+    alternative_names: []
     state: "present"
 
   - name: "files.{{ canonical_hostname }}"

--- a/ansible/roles/packages/tasks/main.yml
+++ b/ansible/roles/packages/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: "install common utilities"
   apt:
-    update_cache: yes
+    update_cache: true
     name:
       - "aptitude"
       - "htop"


### PR DESCRIPTION
Execut website is now hosted on Github pages, so the DNS no longer points at us.