### PR TITLE
Add support for pretix maintenance mode, using variable.

### DIFF
--- a/ansible/group_vars/production/vars.yml
+++ b/ansible/group_vars/production/vars.yml
@@ -69,6 +69,7 @@ secret_pretix:
   # To change, generate a new secret using something like `pwgen 128 1`and
   # re-deploy. Changing this value will invalidate all pretix sessions.
   django_secret: "{{ vault_secret_pretix.django_secret }}"
+  pretix_maintenance_mode: true
 
 secret_static_sticky:
   contentful_space_id: "{{ vault_secret_static_sticky.contentful_space_id }}"

--- a/ansible/group_vars/staging/vars.yml
+++ b/ansible/group_vars/staging/vars.yml
@@ -61,6 +61,7 @@ secret_pretix:
   # To change, generate a new secret using something like `pwgen 128 1`and
   # re-deploy. Changing this value will invalidate all pretix sessions.
   django_secret: "{{ vault_secret_pretix.django_secret }}"
+  pretix_maintenance_mode: true
 
 secret_static_sticky:
   contentful_space_id: "{{ vault_secret_static_sticky.contentful_space_id }}"

--- a/ansible/roles/pretix/tasks/main.yml
+++ b/ansible/roles/pretix/tasks/main.yml
@@ -62,13 +62,19 @@
 
 - name: "create virtualenv if not exists, update pip and tools"
   ansible.builtin.pip:
-    name:
-      - "pip"
-      - "setuptools"
-      - "wheel"
-    state: "latest"
+    name: "{{ item.name }}"
+    version: "{{ item.version }}"
     virtualenv: "/var/www/pretix/venv"
     virtualenv_python: "python3.8"
+    state: "present"
+  with_items:
+    # Change in pip's dependency resolver after 24.0 causes installation of pretix to fail
+    - name: pip
+      version: "24.0"
+    - name: "setuptools"
+      version: "latest"
+    - name: "wheel"
+      version: "latest"
   become: true
   become_user: "pretix"
 
@@ -92,6 +98,7 @@
     state: "present"
     virtualenv: "/var/www/pretix/venv"
     virtualenv_python: "python3.9"
+    
   with_items:
     - name: "gunicorn"
       version: "20.1.0"
@@ -126,7 +133,46 @@
     - "pretix-worker.service"
     - "pretix-runperiodic.timer"
 
+# Maintenance directory, create if maintenance mode
+- name: "ensure pretix maintenance mode directory is present"
+  when: secret_pretix.pretix_maintenance_mode
+  ansible.builtin.file:
+    path: "/var/www/pretix-maintenance"
+    state: "directory"
+    owner: "pretix"
+    group: "pretix"
+
+# Maintenance directory, remove if not maintenance mode
+- name: "ensure pretix maintenance mode directory is present"
+  when: not secret_pretix.pretix_maintenance_mode
+  ansible.builtin.file:
+    path: "/var/www/pretix-maintenance"
+    state: "absent"
+    owner: "pretix"
+    group: "pretix"
+
+# Maintenance mode page
+- name: "Place Maintenance page if maintenance mode is enabled"
+  when: secret_pretix.pretix_maintenance_mode
+  ansible.builtin.template:
+    owner: "pretix"
+    group: "pretix"
+    src: "pretix_maintenance.html.j2"
+    dest: "/var/www/pretix-maintenance/pretix-maintenance.html"
+
+# Maintenance nginx configuration
+- name: "place pretix's maintenace nginx configuration"
+  when: secret_pretix.pretix_maintenance_mode
+  ansible.builtin.template:
+    src: "pretix_maintenance.conf.j2"
+    dest: "/etc/nginx/sites-available/{{ dest_filename }}"
+  vars:
+    dest_filename: "pretix.{{ canonical_hostname }}.conf"
+  notify: "reload nginx"
+
+# Regular nginx configuration
 - name: "place pretix's nginx configuration"
+  when: not secret_pretix.pretix_maintenance_mode
   ansible.builtin.template:
     src: "pretix.conf.j2"
     dest: "/etc/nginx/sites-available/{{ dest_filename }}"
@@ -134,6 +180,7 @@
     dest_filename: "pretix.{{ canonical_hostname }}.conf"
   notify: "reload nginx"
 
+# Does either maintenance mode or regular mode
 - name: "enable pretix's nginx configuration"
   ansible.builtin.file:
     src: "/etc/nginx/sites-available/{{ filename }}"

--- a/ansible/roles/pretix/tasks/main.yml
+++ b/ansible/roles/pretix/tasks/main.yml
@@ -98,7 +98,7 @@
     state: "present"
     virtualenv: "/var/www/pretix/venv"
     virtualenv_python: "python3.9"
-    
+
   with_items:
     - name: "gunicorn"
       version: "20.1.0"

--- a/ansible/roles/pretix/templates/pretix_maintenance.conf.j2
+++ b/ansible/roles/pretix/templates/pretix_maintenance.conf.j2
@@ -1,0 +1,21 @@
+# {{ ansible_managed }}
+
+server {
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+  server_name ~^(pretix|tickets)\.{{ canonical_hostname }};
+
+  ssl_certificate /etc/letsencrypt/live/pretix.{{ canonical_hostname }}/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/pretix.{{ canonical_hostname }}/privkey.pem;
+  ssl_trusted_certificate /etc/letsencrypt/live/pretix.{{ canonical_hostname }}/chain.pem;
+
+  include includes/block-cert-validation-path.conf;
+  add_header Referrer-Policy same-origin;
+  add_header X-XSS-Protection "1; mode=block";
+  add_header X-Content-Type-Options "nosniff";
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  # Security header file not included because frames
+
+  root /var/www/pretix-maintenance;
+  index pretix-maintenance.html;
+}

--- a/ansible/roles/pretix/templates/pretix_maintenance.html.j2
+++ b/ansible/roles/pretix/templates/pretix_maintenance.html.j2
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pretix Maintenance</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f4f4f9;
+            text-align: center;
+            padding: 50px;
+
+        }
+        header {
+            margin-bottom: 50px;
+        }
+        img.banner {
+            max-width: 600px;
+            height: auto;
+        }
+        h1 {
+            color: #333;
+            font-size: 2.5em;
+            margin-top: 30px;
+        }
+        p {
+            color: #666;
+            font-size: 1.2em;
+        }
+    </style>
+</head>
+<body>
+
+    <header>
+        <img class="banner" src="https://public.svsticky.nl/logos/logo_outline_kleur.svg" alt="Logo">
+    </header>
+
+    <h1>Pretix is currently under maintenance</h1>
+    <p>Purchasing tickets is currently not possible.</p>
+    <p>Het kopen van tickets is op dit moment niet mogelijk.</p>
+</body>
+</html>


### PR DESCRIPTION
- Add variable `pretix_maintenance_mode`, setting to true will yield:
![image](https://github.com/user-attachments/assets/2bb9391a-3101-4a4a-bd7a-16a574e8ffff)

- Pin `pip` version. It was broken.