### PR TITLE
fix: latest tag now works for artifacts based deploy

### DIFF
--- a/ansible/group_vars/staging/vars.yml
+++ b/ansible/group_vars/staging/vars.yml
@@ -151,8 +151,8 @@ secret_chroma:
   service_tokens: "{{ vault_secret_chroma.service_tokens }}"
 
 fallacious_rooster:
-  git_tag: "0.1.4"
+  git_tag: "latest"
 
 digidecs:
-  git_tag: "0.1.0"
+  git_tag: "latest"
   server_port: 65437

--- a/ansible/roles/chroma/tasks/main.yaml
+++ b/ansible/roles/chroma/tasks/main.yaml
@@ -37,9 +37,13 @@
       - "python3-dotenv-cli"
     state: "present"
 
+- name: "Determine base url to online artifacts to deploy"
+  ansible.builtin.set_fact:
+    artifact_base_url: "https://github.com/svsticky/chroma/releases/{% if chroma.git_tag == 'latest' %}latest/download{% else %}download/{{ chroma.git_tag }}{% endif %}"
+
 - name: "Download and extract chroma frontend"
   ansible.builtin.unarchive:
-    src: https://github.com/svsticky/chroma/releases/download/{{ chroma.git_tag }}/frontend.tar.gz
+    src: "{{ artifact_base_url }}/frontend.tar.gz"
     dest: "/var/www/chroma/frontend"
     remote_src: true
     owner: "chroma"
@@ -50,7 +54,7 @@
 
 - name: "Download and extract chroma docs"
   ansible.builtin.unarchive:
-    src: https://github.com/svsticky/chroma/releases/download/{{ chroma.git_tag }}/docs.tar.gz
+    src: "{{ artifact_base_url }}/docs.tar.gz"
     dest: "/var/www/chroma/docs"
     remote_src: true
     owner: "chroma"
@@ -61,7 +65,7 @@
 
 - name: "Download and extract chroma server"
   ansible.builtin.get_url:
-    url: https://github.com/svsticky/chroma/releases/download/{{ chroma.git_tag }}/server-x86_64-unknown-linux-musl
+    url: "{{ artifact_base_url }}/server-x86_64-unknown-linux-musl"
     dest: "/var/www/chroma/server"
     owner: "chroma"
     group: "chroma"

--- a/ansible/roles/chroma/tasks/main.yaml
+++ b/ansible/roles/chroma/tasks/main.yaml
@@ -74,7 +74,6 @@
 
 - name: "ensure database user exists"
   community.postgresql.postgresql_user:
-    db: "chroma"
     name: "chroma"
     role_attr_flags: "CREATEDB,LOGIN"
   become_user: "postgres"

--- a/ansible/roles/digidecs/tasks/main.yml
+++ b/ansible/roles/digidecs/tasks/main.yml
@@ -29,9 +29,13 @@
       - "python3-dotenv-cli"
     state: "present"
 
+- name: "Determine base url to online artifacts to deploy"
+  ansible.builtin.set_fact:
+    artifact_base_url: "https://github.com/svsticky/digidecs/releases/{% if digidecs.git_tag == 'latest' %}latest/download{% else %}download/{{ digidecs.git_tag }}{% endif %}"
+
 - name: "Download and extract digidecs frontend"
   ansible.builtin.unarchive:
-    src: https://github.com/svsticky/digidecs/releases/download/{{ digidecs.git_tag }}/frontend.tar.gz
+    src: "{{ artifact_base_url }}/frontend.tar.gz"
     dest: "/var/www/digidecs/frontend"
     remote_src: true
     owner: "digidecs"
@@ -42,7 +46,7 @@
 
 - name: "Download and extract digidecs server"
   ansible.builtin.get_url:
-    url: https://github.com/svsticky/digidecs/releases/download/{{ digidecs.git_tag }}/server-x86_64-unknown-linux-musl
+    url: "{{ artifact_base_url }}/server-x86_64-unknown-linux-musl"
     dest: "/var/www/digidecs/server"
     owner: "digidecs"
     group: "digidecs"

--- a/ansible/roles/rooster/tasks/main.yaml
+++ b/ansible/roles/rooster/tasks/main.yaml
@@ -29,9 +29,13 @@
       - "python3-dotenv-cli"
     state: "present"
 
+- name: "Determine base url to online artifacts to deploy"
+  ansible.builtin.set_fact:
+    artifact_base_url: "https://github.com/svsticky/fallacious-rooster/releases/{% if fallacious_rooster.git_tag == 'latest' %}latest/download{% else %}download/{{ fallacious_rooster.git_tag }}{% endif %}"
+
 - name: "Download and extract fallacious-rooster frontend"
   ansible.builtin.unarchive:
-    src: https://github.com/svsticky/fallacious-rooster/releases/download/{{ fallacious_rooster.git_tag }}/frontend.tar.gz
+    src: "{{ artifact_base_url }}/frontend.tar.gz"
     dest: "/var/www/fallacious-rooster/frontend"
     remote_src: true
     owner: "fallacious-rooster"
@@ -42,7 +46,7 @@
 
 - name: "Download and extract fallacious-rooster server"
   ansible.builtin.get_url:
-    url: https://github.com/svsticky/fallacious-rooster/releases/download/{{ fallacious_rooster.git_tag }}/server-x86_64-unknown-linux-musl
+    url: "{{ artifact_base_url }}/server-x86_64-unknown-linux-musl"
     dest: "/var/www/fallacious-rooster/server"
     owner: "fallacious-rooster"
     group: "fallacious-rooster"


### PR DESCRIPTION
See svsticky/chroma/issues/44

If the git tag is 'latest' and not actually a git tag, the url pointing to the artifacts will be adjusted to not specify a tag but the latest downloads