### PR TITLE
fix: removed conflicting redirections

### DIFF
--- a/ansible/roles/koala/templates/nginx.conf.j2
+++ b/ansible/roles/koala/templates/nginx.conf.j2
@@ -4,13 +4,9 @@ upstream unicorn {
 	server unix:/tmp/unicorn.sock fail_timeout=0;
 }
 
-# maps inschrijven/signup/join.svsticky.nl to wordlid.svsticky.nl
+# TODO this can probably be simplified
 map $http_host $koala_site {
-	default	                                $http_host;
-
-	inschrijven.{{ canonical_hostname }}	wordlid.{{ canonical_hostname }};
-	signup.{{ canonical_hostname }}	      wordlid.{{ canonical_hostname }};
-	join.{{ canonical_hostname }}	        wordlid.{{ canonical_hostname }};
+	default	$http_host;
 }
 
 server {
@@ -20,7 +16,7 @@ server {
 
 	ssl_certificate /etc/letsencrypt/live/koala.{{ canonical_hostname }}/fullchain.pem;
 	ssl_certificate_key /etc/letsencrypt/live/koala.{{ canonical_hostname }}/privkey.pem;
-        ssl_trusted_certificate /etc/letsencrypt/live/koala.{{ canonical_hostname }}/chain.pem;
+	ssl_trusted_certificate /etc/letsencrypt/live/koala.{{ canonical_hostname }}/chain.pem;
 
 	# Security headers already enforced in Rails
 	include includes/block-cert-validation-path.conf;


### PR DESCRIPTION
Aims to solve the 422 errors when authenticating users signup up at alternative domains.

Previously we let nginx do the routing to several sign up pages.

Don't know if this was not the case in the past, but actually signing up was impossible with this setup. Given that we have official domains, we do not need these routings. Removing the routings allows koala to authenticate the user again.

Question: are we doing something wrong that we have to remove this reroutings, given that they have been there for ages?