### PR TITLE
fix: add sleep after docker stop in main website deployment

### DIFF
--- a/ansible/roles/main_website/templates/deploy-main-website.sh.j2
+++ b/ansible/roles/main_website/templates/deploy-main-website.sh.j2
@@ -68,6 +68,7 @@ rsync --delete --recursive . /var/www/main-website/
 # start a new one.
 docker pull ghcr.io/svsticky/main-website-new:$BRANCH_NAME
 docker stop main-website-mail || true # true so that no non-zero exit code is raised
+sleep 12 # Docker waits 10s for the container to gracefully stop, after that it kills it
 docker run --rm -d --name main-website-mail \
   -e HOST=0.0.0.0 -e PORT=4321 \
   {# Don't need a \ at the end because jinja inlines the if statement for some reason #}


### PR DESCRIPTION
The main website some times fails to deploy the docker container because it tries to start a docker container with the same name, which might still be in the process of stopping. Adding a `sleep 12` should allow for enough time for `docker stop` to stop and remove the old container, so that the new container can safely be started reusing the name.